### PR TITLE
Introduce FLEXTableRowDataViewController to view table row data

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "FLEXTableContentViewController.h"
+#import "FLEXTableRowDataViewController.h"
 #import "FLEXMultiColumnTableView.h"
 #import "FLEXWebViewController.h"
 #import "FLEXUtility.h"
@@ -167,6 +168,12 @@
         });
         make.button(@"Copy as CSV").handler(^(NSArray<NSString *> *strings) {
             UIPasteboard.generalPasteboard.string = [values componentsJoinedByString:@", "];
+        });
+        make.button(@"Focus on Row").handler(^(NSArray<NSString *> *strings) {
+            UIViewController *focusedRow = [FLEXTableRowDataViewController
+                rows:[NSDictionary dictionaryWithObjects:self.rows[row] forKeys:self.columns]
+            ];
+            [self.navigationController pushViewController:focusedRow animated:YES];
         });
         
         // Option to delete row

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableRowDataViewController.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableRowDataViewController.h
@@ -1,0 +1,14 @@
+//
+//  FLEXTableRowDataViewController.h
+//  FLEX
+//
+//  Created by Chaoshuai Lu on 7/8/20.
+//
+
+#import "FLEXFilteringTableViewController.h"
+
+@interface FLEXTableRowDataViewController : FLEXFilteringTableViewController
+
++ (instancetype)rows:(NSDictionary<NSString *, id> *)rowData;
+
+@end

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableRowDataViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableRowDataViewController.m
@@ -1,0 +1,54 @@
+//
+//  FLEXTableRowDataViewController.m
+//  FLEX
+//
+//  Created by Chaoshuai Lu on 7/8/20.
+//
+
+#import "FLEXTableRowDataViewController.h"
+#import "FLEXMutableListSection.h"
+#import "FLEXAlert.h"
+
+@interface FLEXTableRowDataViewController ()
+@property (nonatomic) NSDictionary<NSString *, NSString *> *rowsByColumn;
+@end
+
+@implementation FLEXTableRowDataViewController
+
+#pragma mark - Initialization
+
++ (instancetype)rows:(NSDictionary<NSString *, id> *)rowData {
+    FLEXTableRowDataViewController *controller = [self new];
+    controller.rowsByColumn = rowData;
+    return controller;
+}
+
+#pragma mark - Overrides
+
+- (NSArray<FLEXTableViewSection *> *)makeSections {
+    NSDictionary<NSString *, NSString *> *rowsByColumn = self.rowsByColumn;
+    
+    FLEXMutableListSection<NSString *> *section = [FLEXMutableListSection list:self.rowsByColumn.allKeys
+        cellConfiguration:^(UITableViewCell *cell, NSString *column, NSInteger row) {
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.textLabel.text = column;
+            cell.detailTextLabel.text = rowsByColumn[column].description;
+        } filterMatcher:^BOOL(NSString *filterText, NSString *column) {
+            return [column localizedCaseInsensitiveContainsString:filterText] ||
+                [rowsByColumn[column] localizedCaseInsensitiveContainsString:filterText];
+        }
+    ];
+    
+    section.selectionHandler = ^(UIViewController *host, NSString *column) {
+        UIPasteboard.generalPasteboard.string = rowsByColumn[column].description;
+        [FLEXAlert makeAlert:^(FLEXAlert *make) {
+            make.title(@"Column Copied to Clipboard");
+            make.message(rowsByColumn[column].description);
+            make.button(@"Dismiss").cancelStyle();
+        } showFrom:host];
+    };
+
+    return @[section];
+}
+
+@end

--- a/Classes/GlobalStateExplorers/FLEXObjectListViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXObjectListViewController.m
@@ -222,7 +222,7 @@ typedef NS_ENUM(NSUInteger, FLEXObjectReferenceSection) {
     }];
 }
 
-- (FLEXMutableListSection *)makeSection:(NSArray *)rows title:(NSString *)title { weakify(self)
+- (FLEXMutableListSection *)makeSection:(NSArray *)rows title:(NSString *)title {
     FLEXMutableListSection *section = [FLEXMutableListSection list:rows
         cellConfiguration:^(FLEXTableViewCell *cell, FLEXObjectRef *ref, NSInteger row) {
             cell.textLabel.text = ref.reference;
@@ -237,8 +237,8 @@ typedef NS_ENUM(NSUInteger, FLEXObjectReferenceSection) {
         }
     ];
 
-    section.selectionHandler = ^(UIViewController *host, FLEXObjectRef *ref) { strongify(self)
-        [self.navigationController pushViewController:[
+    section.selectionHandler = ^(UIViewController *host, FLEXObjectRef *ref) {
+        [host.navigationController pushViewController:[
             FLEXObjectExplorerFactory explorerViewControllerForObject:ref.object
         ] animated:YES];
     };

--- a/Classes/ObjectExplorers/Sections/FLEXMutableListSection.h
+++ b/Classes/ObjectExplorers/Sections/FLEXMutableListSection.h
@@ -36,7 +36,7 @@ typedef void (^FLEXMutableListCellForElement)(__kindof UITableViewCell *cell, id
 
 /// By default, rows are not selectable. If you want rows
 /// to be selectable, provide a selection handler here.
-@property (nonatomic, copy) void (^selectionHandler)(__kindof UIViewController *host, id element);
+@property (nonatomic, copy) void (^selectionHandler)(__kindof UIViewController *host, ObjectType element);
 
 /// The objects representing all possible rows in the section.
 @property (nonatomic) NSArray<ObjectType> *list;

--- a/FLEX.xcodeproj/project.pbxproj
+++ b/FLEX.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03ED813D24B7D91200831CA0 /* FLEXTableRowDataViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 03ED813B24B7D91200831CA0 /* FLEXTableRowDataViewController.m */; };
+		03ED813E24B7D91200831CA0 /* FLEXTableRowDataViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 03ED813C24B7D91200831CA0 /* FLEXTableRowDataViewController.h */; };
 		04F1CA191C137CF1000A52B0 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 04F1CA181C137CF1000A52B0 /* LICENSE */; };
 		1C27A8B91F0E5A0400F0D02D /* FLEXTestsMethodsList.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C27A8B81F0E5A0400F0D02D /* FLEXTestsMethodsList.m */; };
 		1C27A8BB1F0E5A0400F0D02D /* FLEX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A4C941F1B5B20570088C3F2 /* FLEX.framework */; };
@@ -374,6 +376,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03ED813B24B7D91200831CA0 /* FLEXTableRowDataViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLEXTableRowDataViewController.m; sourceTree = "<group>"; };
+		03ED813C24B7D91200831CA0 /* FLEXTableRowDataViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLEXTableRowDataViewController.h; sourceTree = "<group>"; };
 		04F1CA181C137CF1000A52B0 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		1C27A8B61F0E5A0300F0D02D /* FLEXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FLEXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C27A8B81F0E5A0400F0D02D /* FLEXTestsMethodsList.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FLEXTestsMethodsList.m; sourceTree = "<group>"; };
@@ -1057,6 +1061,8 @@
 				779B1ECB1C0C4D7C001F5E49 /* FLEXTableLeftCell.m */,
 				779B1ECC1C0C4D7C001F5E49 /* FLEXTableListViewController.h */,
 				779B1ECD1C0C4D7C001F5E49 /* FLEXTableListViewController.m */,
+				03ED813C24B7D91200831CA0 /* FLEXTableRowDataViewController.h */,
+				03ED813B24B7D91200831CA0 /* FLEXTableRowDataViewController.m */,
 				04F1CA181C137CF1000A52B0 /* LICENSE */,
 			);
 			path = DatabaseBrowser;
@@ -1511,6 +1517,7 @@
 				3A4C95301B5B21410088C3F2 /* FLEXSystemLogMessage.h in Headers */,
 				C398625523AD6C67007E6793 /* FLEXObjcRuntimeViewController.h in Headers */,
 				C3E5DA02231700EE00E655DB /* FLEXObjectInfoSection.h in Headers */,
+				03ED813E24B7D91200831CA0 /* FLEXTableRowDataViewController.h in Headers */,
 				C34D4EB023A2ABD900C1F903 /* FLEXLayerShortcuts.h in Headers */,
 				C3F646F623A04A7500D4A011 /* FLEXShortcut.h in Headers */,
 				C3531B9D23E69BB200A184AD /* FLEXManager+Networking.h in Headers */,
@@ -1891,6 +1898,7 @@
 				779B1ED31C0C4D7C001F5E49 /* FLEXTableColumnHeader.m in Sources */,
 				C30D2963261FAE9E00D89649 /* FLEXNSStringShortcuts.m in Sources */,
 				C37A0C94218BAC9600848CA7 /* FLEXObjcInternal.mm in Sources */,
+				03ED813D24B7D91200831CA0 /* FLEXTableRowDataViewController.m in Sources */,
 				C31D93E523E38CBE005517BF /* FLEXBlockShortcuts.m in Sources */,
 				C312A13123ECB5D300E38049 /* FLEXBookmarkManager.m in Sources */,
 				C34D4EB523A2AF2A00C1F903 /* FLEXColorPreviewSection.m in Sources */,


### PR DESCRIPTION
Introduce `FLEXTableRowDataViewController` to view table row data.

Currently since FLEX 4.0, if you tap on a specific field on a db cell, the whole row's data will be aggregated and we only show the result in an alert view. This is not ideal since often times one wants to copy a certain value from the cell in order to achieve something else.

So I introduced a new view controller to focus on a certain row to view the data in a better way.

Demos:
<img width=30% src="https://user-images.githubusercontent.com/627231/87098724-d48ab180-c1fc-11ea-9290-20fd7ec0752f.png">  <img width=30% src="https://user-images.githubusercontent.com/627231/87098739-dce2ec80-c1fc-11ea-8a0e-5434ef06d6cd.png">
