### PR TITLE
Show full text for DB browser column headers

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDBQueryRowCell.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDBQueryRowCell.h
@@ -8,12 +8,21 @@
 
 #import <UIKit/UIKit.h>
 
+@class FLEXDBQueryRowCell;
+
 extern NSString * const kFLEXDBQueryRowCellReuse;
 
+@protocol FLEXDBQueryRowCellLayoutSource <NSObject>
+
+- (CGFloat)dbQueryRowCell:(FLEXDBQueryRowCell *)dbQueryRowCell minXForColumn:(NSUInteger)column;
+- (CGFloat)dbQueryRowCell:(FLEXDBQueryRowCell *)dbQueryRowCell widthForColumn:(NSUInteger)column;
+
+@end
 
 @interface FLEXDBQueryRowCell : UITableViewCell
 
 /// An array of NSString, NSNumber, or NSData objects
 @property (nonatomic) NSArray *data;
+@property (nonatomic, weak) id<FLEXDBQueryRowCellLayoutSource> layoutSource;
 
 @end

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDBQueryRowCell.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDBQueryRowCell.m
@@ -63,11 +63,12 @@ NSString * const kFLEXDBQueryRowCellReuse = @"kFLEXDBQueryRowCellReuse";
 - (void)layoutSubviews {
     [super layoutSubviews];
     
-    CGFloat width  = self.contentView.frame.size.width / self.labels.count;
     CGFloat height = self.contentView.frame.size.height;
     
     [self.labels flex_forEach:^(UILabel *label, NSUInteger i) {
-        label.frame = CGRectMake(width * i + 5, 0, (width - 10), height);
+        CGFloat width = [self.layoutSource dbQueryRowCell:self widthForColumn:i];
+        CGFloat minX = [self.layoutSource dbQueryRowCell:self minXForColumn:i];
+        label.frame = CGRectMake(minX + 5, 0, (width - 10), height);
     }];
 }
 

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.h
@@ -29,7 +29,7 @@
 - (NSString *)rowTitle:(NSInteger)row;
 - (NSArray<NSString *> *)contentForRow:(NSInteger)row;
 
-- (CGFloat)multiColumnTableView:(FLEXMultiColumnTableView *)tableView widthForContentCellInColumn:(NSInteger)column;
+- (CGFloat)multiColumnTableView:(FLEXMultiColumnTableView *)tableView minWidthForContentCellInColumn:(NSInteger)column;
 - (CGFloat)multiColumnTableView:(FLEXMultiColumnTableView *)tableView heightForContentCellInRow:(NSInteger)row;
 - (CGFloat)heightForTopHeaderInTableView:(FLEXMultiColumnTableView *)tableView;
 - (CGFloat)widthForLeftHeaderInTableView:(FLEXMultiColumnTableView *)tableView;

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableColumnHeader.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableColumnHeader.m
@@ -11,6 +11,9 @@
 #import "UIFont+FLEX.h"
 #import "FLEXUtility.h"
 
+static const CGFloat kMargin = 5;
+static const CGFloat kArrowWidth = 20;
+
 @interface FLEXTableColumnHeader ()
 @property (nonatomic, readonly) UILabel *arrowLabel;
 @property (nonatomic, readonly) UIView *lineView;
@@ -60,9 +63,16 @@
     
     CGSize size = self.frame.size;
     
-    self.titleLabel.frame = CGRectMake(5, 0, size.width - 25, size.height);
-    self.arrowLabel.frame = CGRectMake(size.width - 20, 0, 20, size.height);
+    self.titleLabel.frame = CGRectMake(kMargin, 0, size.width - kArrowWidth - kMargin, size.height);
+    self.arrowLabel.frame = CGRectMake(size.width - kArrowWidth, 0, kArrowWidth, size.height);
     self.lineView.frame = CGRectMake(size.width - 1, 2, FLEXPointsToPixels(1), size.height - 4);
+}
+
+- (CGSize)sizeThatFits:(CGSize)size {
+    CGFloat margins = kArrowWidth - 2 * kMargin;
+    size = CGSizeMake(size.width - margins, size.height);
+    CGFloat width = [_titleLabel sizeThatFits:size].width + margins;
+    return CGSizeMake(width, size.height);
 }
 
 @end

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -84,8 +84,8 @@
 }
 
 - (CGFloat)multiColumnTableView:(FLEXMultiColumnTableView *)tableView
-    widthForContentCellInColumn:(NSInteger)column {
-    return 120;
+    minWidthForContentCellInColumn:(NSInteger)column {
+    return 100;
 }
 
 - (CGFloat)heightForTopHeaderInTableView:(FLEXMultiColumnTableView *)tableView {

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -127,13 +127,19 @@
                     sortType:(FLEXTableColumnHeaderSortType)sortType {
     
     NSArray<NSArray *> *sortContentData = [self.rows
-        sortedArrayUsingComparator:^NSComparisonResult(NSArray *obj1, NSArray *obj2) {
+        sortedArrayWithOptions:NSSortStable
+        usingComparator:^NSComparisonResult(NSArray *obj1, NSArray *obj2) {
             id a = obj1[column], b = obj2[column];
             if (a == NSNull.null) {
                 return NSOrderedAscending;
             }
             if (b == NSNull.null) {
                 return NSOrderedDescending;
+            }
+        
+            if ([a respondsToSelector:@selector(compare:options:)] &&
+                [b respondsToSelector:@selector(compare:options:)]) {
+                return [a compare:b options:NSNumericSearch];
             }
             
             if ([a respondsToSelector:@selector(compare:)] && [b respondsToSelector:@selector(compare:)]) {


### PR DESCRIPTION
Show full text for DB browser column headers.

Currently the header has a fixed width of 120pts. This isn't ideal as some of the columns will have names that cannot fit, and user cannot expand its width like Excel or Google Spreadsheet.

So in this PR I'm trying to use `MAX(120pt, sizeThatFits)` as the width of the header and content, so that they can be consumed in a better way.