### PR TITLE
Fix crash when sharing single file on iPad

### DIFF
--- a/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserController.m
+++ b/Classes/GlobalStateExplorers/FileBrowser/FLEXFileBrowserController.m
@@ -474,6 +474,9 @@ contextMenuConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath
     } else {
         // Share sheet for files
         UIActivityViewController *shareSheet = [[UIActivityViewController alloc] initWithActivityItems:@[filePath] applicationActivities:nil];
+        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+            shareSheet.popoverPresentationController.sourceView = sender;
+        }
         [self presentViewController:shareSheet animated:true completion:nil];
     }
 }


### PR DESCRIPTION
Fixing the crash on sharing single file on iPad by setting the `shareSheet.popoverPresentationController.sourceView = sender`
error:
```swift
Terminating app due to uncaught exception 'NSGenericException', 
reason: 'UIPopoverPresentationController (<UIPopoverPresentationController: 0x7fc18ec54320>) should have a non-nil sourceView or barButtonItem set before the presentation occurs.'
```