### PR TITLE
Fix crash on `flex_withTintColor`

### DIFF
--- a/Classes/Utility/Categories/UIBarButtonItem+FLEX.m
+++ b/Classes/Utility/Categories/UIBarButtonItem+FLEX.m
@@ -64,7 +64,7 @@
     return item;
 }
 
-- (UIBarButtonItem *)withTintColor:(UIColor *)tint {
+- (UIBarButtonItem *)flex_withTintColor:(UIColor *)tint {
     self.tintColor = tint;
     return self;
 }


### PR DESCRIPTION
Hi,

There is a crash when you open Network History. Method unrecognized `flex_withTintColor`. I discovered that naming is incorrect in header and implementation (.m).

`Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[UIBarButtonItem flex_withTintColor:]: unrecognized selector sent to instance 0x7fafcfe6d1f0'`

Please, consider this MR. 

Thanks for your work!