### PR TITLE
Swift Package Manager support

### DIFF
--- a/Classes/FLEX-Categories.h
+++ b/Classes/FLEX-Categories.h
@@ -6,17 +6,25 @@
 //  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
+#import "UIBarButtonItem+FLEX.h"
+#import "CALayer+FLEX.h"
+#import "UIFont+FLEX.h"
+#import "UIGestureRecognizer+Blocks.h"
+#import "UIView+FLEX_Layout.h"
+#import "UIPasteboard+FLEX.h"
+#import "UIMenu+FLEX.h"
+#import "UITextField+Range.h"
 
 
-#import <FLEX/UIBarButtonItem+FLEX.h>
-#import <FLEX/CALayer+FLEX.h>
-#import <FLEX/UIFont+FLEX.h>
-#import <FLEX/UIGestureRecognizer+Blocks.h>
-#import <FLEX/UIPasteboard+FLEX.h>
-#import <FLEX/UIMenu+FLEX.h>
-#import <FLEX/UITextField+Range.h>
+#import "UIBarButtonItem+FLEX.h"
+#import "CALayer+FLEX.h"
+#import "UIFont+FLEX.h"
+#import "UIGestureRecognizer+Blocks.h"
+#import "UIPasteboard+FLEX.h"
+#import "UIMenu+FLEX.h"
+#import "UITextField+Range.h"
 
-#import <FLEX/NSObject+FLEX_Reflection.h>
-#import <FLEX/NSArray+FLEX.h>
-#import <FLEX/NSUserDefaults+FLEX.h>
-#import <FLEX/NSTimer+FLEX.h>
+#import "NSObject+FLEX_Reflection.h"
+#import "NSArray+FLEX.h"
+#import "NSUserDefaults+FLEX.h"
+#import "NSTimer+FLEX.h"

--- a/Classes/FLEX-Core.h
+++ b/Classes/FLEX-Core.h
@@ -6,18 +6,18 @@
 //  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
-#import <FLEX/FLEXFilteringTableViewController.h>
-#import <FLEX/FLEXNavigationController.h>
-#import <FLEX/FLEXTableViewController.h>
-#import <FLEX/FLEXTableView.h>
+#import "FLEXFilteringTableViewController.h"
+#import "FLEXNavigationController.h"
+#import "FLEXTableViewController.h"
+#import "FLEXTableView.h"
 
-#import <FLEX/FLEXSingleRowSection.h>
-#import <FLEX/FLEXTableViewSection.h>
+#import "FLEXSingleRowSection.h"
+#import "FLEXTableViewSection.h"
 
-#import <FLEX/FLEXCodeFontCell.h>
-#import <FLEX/FLEXSubtitleTableViewCell.h>
-#import <FLEX/FLEXTableViewCell.h>
-#import <FLEX/FLEXMultilineTableViewCell.h>
-#import <FLEX/FLEXKeyValueTableViewCell.h>
+#import "FLEXCodeFontCell.h"
+#import "FLEXSubtitleTableViewCell.h"
+#import "FLEXTableViewCell.h"
+#import "FLEXMultilineTableViewCell.h"
+#import "FLEXKeyValueTableViewCell.h"
 
-#import <FLEX/FLEXScopeCarousel.h>
+#import "FLEXScopeCarousel.h"

--- a/Classes/FLEX-ObjectExploring.h
+++ b/Classes/FLEX-ObjectExploring.h
@@ -6,25 +6,25 @@
 //  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
-#import <FLEX/FLEXObjectExplorerFactory.h>
-#import <FLEX/FLEXObjectExplorerViewController.h>
+#import "FLEXObjectExplorerFactory.h"
+#import "FLEXObjectExplorerViewController.h"
 
-#import <FLEX/FLEXObjectExplorer.h>
+#import "FLEXObjectExplorer.h"
 
-#import <FLEX/FLEXShortcut.h>
-#import <FLEX/FLEXShortcutsFactory+Defaults.h>
-#import <FLEX/FLEXShortcutsSection.h>
-#import <FLEX/FLEXBlockShortcuts.h>
-#import <FLEX/FLEXBundleShortcuts.h>
-#import <FLEX/FLEXClassShortcuts.h>
-#import <FLEX/FLEXImageShortcuts.h>
-#import <FLEX/FLEXLayerShortcuts.h>
-#import <FLEX/FLEXViewControllerShortcuts.h>
-#import <FLEX/FLEXViewShortcuts.h>
+#import "FLEXShortcut.h"
+#import "FLEXShortcutsFactory+Defaults.h"
+#import "FLEXShortcutsSection.h"
+#import "FLEXBlockShortcuts.h"
+#import "FLEXBundleShortcuts.h"
+#import "FLEXClassShortcuts.h"
+#import "FLEXImageShortcuts.h"
+#import "FLEXLayerShortcuts.h"
+#import "FLEXViewControllerShortcuts.h"
+#import "FLEXViewShortcuts.h"
 
-#import <FLEX/FLEXCollectionContentSection.h>
-#import <FLEX/FLEXColorPreviewSection.h>
-#import <FLEX/FLEXDefaultsContentSection.h>
-#import <FLEX/FLEXMetadataSection.h>
-#import <FLEX/FLEXMutableListSection.h>
-#import <FLEX/FLEXObjectInfoSection.h>
+#import "FLEXCollectionContentSection.h"
+#import "FLEXColorPreviewSection.h"
+#import "FLEXDefaultsContentSection.h"
+#import "FLEXMetadataSection.h"
+#import "FLEXMutableListSection.h"
+#import "FLEXObjectInfoSection.h"

--- a/Classes/FLEX-Runtime.h
+++ b/Classes/FLEX-Runtime.h
@@ -6,20 +6,20 @@
 //  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
-#import <FLEX/FLEXObjcInternal.h>
-#import <FLEX/FLEXRuntimeSafety.h>
-#import <FLEX/FLEXBlockDescription.h>
-#import <FLEX/FLEXTypeEncodingParser.h>
+#import "FLEXObjcInternal.h"
+#import "FLEXRuntimeSafety.h"
+#import "FLEXBlockDescription.h"
+#import "FLEXTypeEncodingParser.h"
 
-#import <FLEX/FLEXMirror.h>
-#import <FLEX/FLEXProtocol.h>
-#import <FLEX/FLEXProperty.h>
-#import <FLEX/FLEXIvar.h>
-#import <FLEX/FLEXMethodBase.h>
-#import <FLEX/FLEXMethod.h>
-#import <FLEX/FLEXPropertyAttributes.h>
-#import <FLEX/FLEXRuntime+Compare.h>
-#import <FLEX/FLEXRuntime+UIKitHelpers.h>
+#import "FLEXMirror.h"
+#import "FLEXProtocol.h"
+#import "FLEXProperty.h"
+#import "FLEXIvar.h"
+#import "FLEXMethodBase.h"
+#import "FLEXMethod.h"
+#import "FLEXPropertyAttributes.h"
+#import "FLEXRuntime+Compare.h"
+#import "FLEXRuntime+UIKitHelpers.h"
 
-#import <FLEX/FLEXProtocolBuilder.h>
-#import <FLEX/FLEXClassBuilder.h>
+#import "FLEXProtocolBuilder.h"
+#import "FLEXClassBuilder.h"

--- a/Classes/FLEX.h
+++ b/Classes/FLEX.h
@@ -7,18 +7,19 @@
 //  Copyright (c) 2020 FLEX Team. All rights reserved.
 //
 
-#import <FLEX/FLEXManager.h>
-#import <FLEX/FLEXManager+Extensibility.h>
-#import <FLEX/FLEXManager+Networking.h>
+#import "FLEXManager.h"
+#import "FLEXManager+Extensibility.h"
+#import "FLEXManager+Networking.h"
 
-#import <FLEX/FLEXExplorerToolbar.h>
-#import <FLEX/FLEXExplorerToolbarItem.h>
-#import <FLEX/FLEXGlobalsEntry.h>
+#import "FLEXExplorerToolbar.h"
+#import "FLEXExplorerToolbarItem.h"
+#import "FLEXGlobalsEntry.h"
 
-#import <FLEX/FLEX-Core.h>
-#import <FLEX/FLEX-Runtime.h>
-#import <FLEX/FLEX-Categories.h>
-#import <FLEX/FLEX-ObjectExploring.h>
+#import "FLEX-Core.h"
+#import "FLEX-Runtime.h"
+#import "FLEX-Categories.h"
+#import "FLEX-ObjectExploring.h"
 
-#import <FLEX/FLEXAlert.h>
-#import <FLEX/FLEXResources.h>
+#import "FLEXMacros.h"
+#import "FLEXAlert.h"
+#import "FLEXResources.h"

--- a/Classes/Headers/CALayer+FLEX.h
+++ b/Classes/Headers/CALayer+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/CALayer+FLEX.h

--- a/Classes/Headers/FLEX-Categories.h
+++ b/Classes/Headers/FLEX-Categories.h
@@ -1,0 +1,1 @@
+../../Classes/FLEX-Categories.h

--- a/Classes/Headers/FLEX-Core.h
+++ b/Classes/Headers/FLEX-Core.h
@@ -1,0 +1,1 @@
+../../Classes/FLEX-Core.h

--- a/Classes/Headers/FLEX-ObjectExploring.h
+++ b/Classes/Headers/FLEX-ObjectExploring.h
@@ -1,0 +1,1 @@
+../../Classes/FLEX-ObjectExploring.h

--- a/Classes/Headers/FLEX-Runtime.h
+++ b/Classes/Headers/FLEX-Runtime.h
@@ -1,0 +1,1 @@
+../../Classes/FLEX-Runtime.h

--- a/Classes/Headers/FLEX.h
+++ b/Classes/Headers/FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/FLEX.h

--- a/Classes/Headers/FLEXAlert.h
+++ b/Classes/Headers/FLEXAlert.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/FLEXAlert.h

--- a/Classes/Headers/FLEXArgumentInputColorView.h
+++ b/Classes/Headers/FLEXArgumentInputColorView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputColorView.h

--- a/Classes/Headers/FLEXArgumentInputDateView.h
+++ b/Classes/Headers/FLEXArgumentInputDateView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputDateView.h

--- a/Classes/Headers/FLEXArgumentInputFontView.h
+++ b/Classes/Headers/FLEXArgumentInputFontView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontView.h

--- a/Classes/Headers/FLEXArgumentInputFontsPickerView.h
+++ b/Classes/Headers/FLEXArgumentInputFontsPickerView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontsPickerView.h

--- a/Classes/Headers/FLEXArgumentInputNotSupportedView.h
+++ b/Classes/Headers/FLEXArgumentInputNotSupportedView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputNotSupportedView.h

--- a/Classes/Headers/FLEXArgumentInputNumberView.h
+++ b/Classes/Headers/FLEXArgumentInputNumberView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputNumberView.h

--- a/Classes/Headers/FLEXArgumentInputObjectView.h
+++ b/Classes/Headers/FLEXArgumentInputObjectView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputObjectView.h

--- a/Classes/Headers/FLEXArgumentInputStringView.h
+++ b/Classes/Headers/FLEXArgumentInputStringView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputStringView.h

--- a/Classes/Headers/FLEXArgumentInputStructView.h
+++ b/Classes/Headers/FLEXArgumentInputStructView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputStructView.h

--- a/Classes/Headers/FLEXArgumentInputSwitchView.h
+++ b/Classes/Headers/FLEXArgumentInputSwitchView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputSwitchView.h

--- a/Classes/Headers/FLEXArgumentInputTextView.h
+++ b/Classes/Headers/FLEXArgumentInputTextView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.h

--- a/Classes/Headers/FLEXArgumentInputView.h
+++ b/Classes/Headers/FLEXArgumentInputView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/ArgumentInputViews/FLEXArgumentInputView.h

--- a/Classes/Headers/FLEXArgumentInputViewFactory.h
+++ b/Classes/Headers/FLEXArgumentInputViewFactory.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/FLEXArgumentInputViewFactory.h

--- a/Classes/Headers/FLEXBlockDescription.h
+++ b/Classes/Headers/FLEXBlockDescription.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXBlockDescription.h

--- a/Classes/Headers/FLEXBlockShortcuts.h
+++ b/Classes/Headers/FLEXBlockShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXBlockShortcuts.h

--- a/Classes/Headers/FLEXBundleShortcuts.h
+++ b/Classes/Headers/FLEXBundleShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXBundleShortcuts.h

--- a/Classes/Headers/FLEXCarouselCell.h
+++ b/Classes/Headers/FLEXCarouselCell.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/Carousel/FLEXCarouselCell.h

--- a/Classes/Headers/FLEXClassBuilder.h
+++ b/Classes/Headers/FLEXClassBuilder.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXClassBuilder.h

--- a/Classes/Headers/FLEXClassShortcuts.h
+++ b/Classes/Headers/FLEXClassShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXClassShortcuts.h

--- a/Classes/Headers/FLEXCodeFontCell.h
+++ b/Classes/Headers/FLEXCodeFontCell.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/Cells/FLEXCodeFontCell.h

--- a/Classes/Headers/FLEXCollectionContentSection.h
+++ b/Classes/Headers/FLEXCollectionContentSection.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/FLEXCollectionContentSection.h

--- a/Classes/Headers/FLEXColorPreviewSection.h
+++ b/Classes/Headers/FLEXColorPreviewSection.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/FLEXColorPreviewSection.h

--- a/Classes/Headers/FLEXDefaultEditorViewController.h
+++ b/Classes/Headers/FLEXDefaultEditorViewController.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/FLEXDefaultEditorViewController.h

--- a/Classes/Headers/FLEXDefaultsContentSection.h
+++ b/Classes/Headers/FLEXDefaultsContentSection.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/FLEXDefaultsContentSection.h

--- a/Classes/Headers/FLEXExplorerToolbar.h
+++ b/Classes/Headers/FLEXExplorerToolbar.h
@@ -1,0 +1,1 @@
+../../Classes/Toolbar/FLEXExplorerToolbar.h

--- a/Classes/Headers/FLEXExplorerToolbarItem.h
+++ b/Classes/Headers/FLEXExplorerToolbarItem.h
@@ -1,0 +1,1 @@
+../../Classes/Toolbar/FLEXExplorerToolbarItem.h

--- a/Classes/Headers/FLEXFieldEditorView.h
+++ b/Classes/Headers/FLEXFieldEditorView.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/FLEXFieldEditorView.h

--- a/Classes/Headers/FLEXFieldEditorViewController.h
+++ b/Classes/Headers/FLEXFieldEditorViewController.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/FLEXFieldEditorViewController.h

--- a/Classes/Headers/FLEXFilteringTableViewController.h
+++ b/Classes/Headers/FLEXFilteringTableViewController.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Controllers/FLEXFilteringTableViewController.h

--- a/Classes/Headers/FLEXGlobalsEntry.h
+++ b/Classes/Headers/FLEXGlobalsEntry.h
@@ -1,0 +1,1 @@
+../../Classes/GlobalStateExplorers/Globals/FLEXGlobalsEntry.h

--- a/Classes/Headers/FLEXImageShortcuts.h
+++ b/Classes/Headers/FLEXImageShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXImageShortcuts.h

--- a/Classes/Headers/FLEXIvar.h
+++ b/Classes/Headers/FLEXIvar.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.h

--- a/Classes/Headers/FLEXKeyValueTableViewCell.h
+++ b/Classes/Headers/FLEXKeyValueTableViewCell.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/Cells/FLEXKeyValueTableViewCell.h

--- a/Classes/Headers/FLEXLayerShortcuts.h
+++ b/Classes/Headers/FLEXLayerShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXLayerShortcuts.h

--- a/Classes/Headers/FLEXMacros.h
+++ b/Classes/Headers/FLEXMacros.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/FLEXMacros.h

--- a/Classes/Headers/FLEXManager+Extensibility.h
+++ b/Classes/Headers/FLEXManager+Extensibility.h
@@ -1,0 +1,1 @@
+../../Classes/Manager/FLEXManager+Extensibility.h

--- a/Classes/Headers/FLEXManager+Networking.h
+++ b/Classes/Headers/FLEXManager+Networking.h
@@ -1,0 +1,1 @@
+../../Classes/Manager/FLEXManager+Networking.h

--- a/Classes/Headers/FLEXManager.h
+++ b/Classes/Headers/FLEXManager.h
@@ -1,0 +1,1 @@
+../../Classes/Manager/FLEXManager.h

--- a/Classes/Headers/FLEXMetadataSection.h
+++ b/Classes/Headers/FLEXMetadataSection.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/FLEXMetadataSection.h

--- a/Classes/Headers/FLEXMethod.h
+++ b/Classes/Headers/FLEXMethod.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXMethod.h

--- a/Classes/Headers/FLEXMethodBase.h
+++ b/Classes/Headers/FLEXMethodBase.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXMethodBase.h

--- a/Classes/Headers/FLEXMethodCallingViewController.h
+++ b/Classes/Headers/FLEXMethodCallingViewController.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/FLEXMethodCallingViewController.h

--- a/Classes/Headers/FLEXMirror.h
+++ b/Classes/Headers/FLEXMirror.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXMirror.h

--- a/Classes/Headers/FLEXMultilineTableViewCell.h
+++ b/Classes/Headers/FLEXMultilineTableViewCell.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/Cells/FLEXMultilineTableViewCell.h

--- a/Classes/Headers/FLEXMutableListSection.h
+++ b/Classes/Headers/FLEXMutableListSection.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/FLEXMutableListSection.h

--- a/Classes/Headers/FLEXNavigationController.h
+++ b/Classes/Headers/FLEXNavigationController.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Controllers/FLEXNavigationController.h

--- a/Classes/Headers/FLEXObjcInternal.h
+++ b/Classes/Headers/FLEXObjcInternal.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/FLEXObjcInternal.h

--- a/Classes/Headers/FLEXObjectExplorer.h
+++ b/Classes/Headers/FLEXObjectExplorer.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/FLEXObjectExplorer.h

--- a/Classes/Headers/FLEXObjectExplorerFactory.h
+++ b/Classes/Headers/FLEXObjectExplorerFactory.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/FLEXObjectExplorerFactory.h

--- a/Classes/Headers/FLEXObjectExplorerViewController.h
+++ b/Classes/Headers/FLEXObjectExplorerViewController.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/FLEXObjectExplorerViewController.h

--- a/Classes/Headers/FLEXObjectInfoSection.h
+++ b/Classes/Headers/FLEXObjectInfoSection.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/FLEXObjectInfoSection.h

--- a/Classes/Headers/FLEXProperty.h
+++ b/Classes/Headers/FLEXProperty.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXProperty.h

--- a/Classes/Headers/FLEXPropertyAttributes.h
+++ b/Classes/Headers/FLEXPropertyAttributes.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXPropertyAttributes.h

--- a/Classes/Headers/FLEXProtocol.h
+++ b/Classes/Headers/FLEXProtocol.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.h

--- a/Classes/Headers/FLEXProtocolBuilder.h
+++ b/Classes/Headers/FLEXProtocolBuilder.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/Reflection/FLEXProtocolBuilder.h

--- a/Classes/Headers/FLEXResources.h
+++ b/Classes/Headers/FLEXResources.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/FLEXResources.h

--- a/Classes/Headers/FLEXRuntime+Compare.h
+++ b/Classes/Headers/FLEXRuntime+Compare.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/FLEXRuntime+Compare.h

--- a/Classes/Headers/FLEXRuntime+UIKitHelpers.h
+++ b/Classes/Headers/FLEXRuntime+UIKitHelpers.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/FLEXRuntime+UIKitHelpers.h

--- a/Classes/Headers/FLEXRuntimeConstants.h
+++ b/Classes/Headers/FLEXRuntimeConstants.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/FLEXRuntimeConstants.h

--- a/Classes/Headers/FLEXRuntimeSafety.h
+++ b/Classes/Headers/FLEXRuntimeSafety.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/FLEXRuntimeSafety.h

--- a/Classes/Headers/FLEXScopeCarousel.h
+++ b/Classes/Headers/FLEXScopeCarousel.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/Carousel/FLEXScopeCarousel.h

--- a/Classes/Headers/FLEXShortcut.h
+++ b/Classes/Headers/FLEXShortcut.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXShortcut.h

--- a/Classes/Headers/FLEXShortcutsFactory+Defaults.h
+++ b/Classes/Headers/FLEXShortcutsFactory+Defaults.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXShortcutsFactory+Defaults.h

--- a/Classes/Headers/FLEXShortcutsSection.h
+++ b/Classes/Headers/FLEXShortcutsSection.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXShortcutsSection.h

--- a/Classes/Headers/FLEXSingleRowSection.h
+++ b/Classes/Headers/FLEXSingleRowSection.h
@@ -1,0 +1,1 @@
+../../Classes/Core/FLEXSingleRowSection.h

--- a/Classes/Headers/FLEXSubtitleTableViewCell.h
+++ b/Classes/Headers/FLEXSubtitleTableViewCell.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/Cells/FLEXSubtitleTableViewCell.h

--- a/Classes/Headers/FLEXTableView.h
+++ b/Classes/Headers/FLEXTableView.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/FLEXTableView.h

--- a/Classes/Headers/FLEXTableViewCell.h
+++ b/Classes/Headers/FLEXTableViewCell.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Views/Cells/FLEXTableViewCell.h

--- a/Classes/Headers/FLEXTableViewController.h
+++ b/Classes/Headers/FLEXTableViewController.h
@@ -1,0 +1,1 @@
+../../Classes/Core/Controllers/FLEXTableViewController.h

--- a/Classes/Headers/FLEXTableViewSection.h
+++ b/Classes/Headers/FLEXTableViewSection.h
@@ -1,0 +1,1 @@
+../../Classes/Core/FLEXTableViewSection.h

--- a/Classes/Headers/FLEXTypeEncodingParser.h
+++ b/Classes/Headers/FLEXTypeEncodingParser.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Runtime/Objc/FLEXTypeEncodingParser.h

--- a/Classes/Headers/FLEXUIAppShortcuts.h
+++ b/Classes/Headers/FLEXUIAppShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXUIAppShortcuts.h

--- a/Classes/Headers/FLEXVariableEditorViewController.h
+++ b/Classes/Headers/FLEXVariableEditorViewController.h
@@ -1,0 +1,1 @@
+../../Classes/Editing/FLEXVariableEditorViewController.h

--- a/Classes/Headers/FLEXViewControllerShortcuts.h
+++ b/Classes/Headers/FLEXViewControllerShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewControllerShortcuts.h

--- a/Classes/Headers/FLEXViewShortcuts.h
+++ b/Classes/Headers/FLEXViewShortcuts.h
@@ -1,0 +1,1 @@
+../../Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.h

--- a/Classes/Headers/NSArray+FLEX.h
+++ b/Classes/Headers/NSArray+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSArray+FLEX.h

--- a/Classes/Headers/NSDictionary+ObjcRuntime.h
+++ b/Classes/Headers/NSDictionary+ObjcRuntime.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSDictionary+ObjcRuntime.h

--- a/Classes/Headers/NSMapTable+FLEX_Subscripting.h
+++ b/Classes/Headers/NSMapTable+FLEX_Subscripting.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSMapTable+FLEX_Subscripting.h

--- a/Classes/Headers/NSObject+FLEX_Reflection.h
+++ b/Classes/Headers/NSObject+FLEX_Reflection.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSObject+FLEX_Reflection.h

--- a/Classes/Headers/NSString+FLEX.h
+++ b/Classes/Headers/NSString+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSString+FLEX.h

--- a/Classes/Headers/NSString+ObjcRuntime.h
+++ b/Classes/Headers/NSString+ObjcRuntime.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSString+ObjcRuntime.h

--- a/Classes/Headers/NSTimer+FLEX.h
+++ b/Classes/Headers/NSTimer+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSTimer+FLEX.h

--- a/Classes/Headers/NSUserDefaults+FLEX.h
+++ b/Classes/Headers/NSUserDefaults+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/NSUserDefaults+FLEX.h

--- a/Classes/Headers/UIBarButtonItem+FLEX.h
+++ b/Classes/Headers/UIBarButtonItem+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/UIBarButtonItem+FLEX.h

--- a/Classes/Headers/UIFont+FLEX.h
+++ b/Classes/Headers/UIFont+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/UIFont+FLEX.h

--- a/Classes/Headers/UIGestureRecognizer+Blocks.h
+++ b/Classes/Headers/UIGestureRecognizer+Blocks.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/UIGestureRecognizer+Blocks.h

--- a/Classes/Headers/UIMenu+FLEX.h
+++ b/Classes/Headers/UIMenu+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/UIMenu+FLEX.h

--- a/Classes/Headers/UIPasteboard+FLEX.h
+++ b/Classes/Headers/UIPasteboard+FLEX.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/UIPasteboard+FLEX.h

--- a/Classes/Headers/UITextField+Range.h
+++ b/Classes/Headers/UITextField+Range.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/UITextField+Range.h

--- a/Classes/Headers/UIView+FLEX_Layout.h
+++ b/Classes/Headers/UIView+FLEX_Layout.h
@@ -1,0 +1,1 @@
+../../Classes/Utility/Categories/UIView+FLEX_Layout.h

--- a/Example/FLEXample.xcodeproj/project.pbxproj
+++ b/Example/FLEXample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -25,11 +25,10 @@
 		C3A67856241AB8AD005A4681 /* MiscNetworkRequests.m in Sources */ = {isa = PBXBuildFile; fileRef = C3A67855241AB8AD005A4681 /* MiscNetworkRequests.m */; };
 		C3A67858241ADDF7005A4681 /* Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A67857241ADDF7005A4681 /* Commit.swift */; };
 		C3B3760025B8CDA300AD43AB /* Person.m in Sources */ = {isa = PBXBuildFile; fileRef = C3B375FF25B8CDA300AD43AB /* Person.m */; };
+		C3DCDF012641CF5D00D74C57 /* FLEX in Frameworks */ = {isa = PBXBuildFile; productRef = C3DCDF002641CF5D00D74C57 /* FLEX */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		05F97E8666E04B043AC919BA /* Pods-FLEXample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FLEXample.release.xcconfig"; path = "Target Support Files/Pods-FLEXample/Pods-FLEXample.release.xcconfig"; sourceTree = "<group>"; };
-		9FD21AEF548AD7B89327EEFB /* Pods-FLEXample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FLEXample.debug.xcconfig"; path = "Target Support Files/Pods-FLEXample/Pods-FLEXample.debug.xcconfig"; sourceTree = "<group>"; };
 		A5FFDDD9C2278C79FFA0295B /* libPods-FLEXample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FLEXample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C386D6CC2419975A00699085 /* FLEXample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FLEXample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C386D6CF2419975A00699085 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -65,6 +64,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7CB8C28DD5EC2AF347FE6AE4 /* libPods-FLEXample.a in Frameworks */,
+				C3DCDF012641CF5D00D74C57 /* FLEX in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,7 +85,6 @@
 				C386D6CE2419975A00699085 /* FLEXample */,
 				C3A67853241AB88F005A4681 /* Realm */,
 				C386D6CD2419975A00699085 /* Products */,
-				E367791A4E4085CCB945F0F8 /* Pods */,
 				8C3080FE45370D3EC44ADD5D /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -169,15 +168,6 @@
 			path = Realm;
 			sourceTree = "<group>";
 		};
-		E367791A4E4085CCB945F0F8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				9FD21AEF548AD7B89327EEFB /* Pods-FLEXample.debug.xcconfig */,
-				05F97E8666E04B043AC919BA /* Pods-FLEXample.release.xcconfig */,
-			);
-			path = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -196,6 +186,7 @@
 			);
 			name = FLEXample;
 			packageProductDependencies = (
+				C3DCDF002641CF5D00D74C57 /* FLEX */,
 			);
 			productName = FLEXample;
 			productReference = C386D6CC2419975A00699085 /* FLEXample.app */;
@@ -227,6 +218,7 @@
 			);
 			mainGroup = C386D6C32419975A00699085;
 			packageReferences = (
+				C3DCDEFF2641CF5D00D74C57 /* XCRemoteSwiftPackageReference "FLEX" */,
 			);
 			productRefGroup = C386D6CD2419975A00699085 /* Products */;
 			projectDirPath = "";
@@ -429,7 +421,6 @@
 		};
 		C386D6E12419975B00699085 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9FD21AEF548AD7B89327EEFB /* Pods-FLEXample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -454,7 +445,6 @@
 		};
 		C386D6E22419975B00699085 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 05F97E8666E04B043AC919BA /* Pods-FLEXample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -498,6 +488,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C3DCDEFF2641CF5D00D74C57 /* XCRemoteSwiftPackageReference "FLEX" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDOSLabs/FLEX";
+			requirement = {
+				branch = feature/spm;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C3DCDF002641CF5D00D74C57 /* FLEX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C3DCDEFF2641CF5D00D74C57 /* XCRemoteSwiftPackageReference "FLEX" */;
+			productName = FLEX;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C386D6C42419975A00699085 /* Project object */;
 }

--- a/Example/FLEXample.xcodeproj/project.pbxproj
+++ b/Example/FLEXample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7CB8C28DD5EC2AF347FE6AE4 /* libPods-FLEXample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A5FFDDD9C2278C79FFA0295B /* libPods-FLEXample.a */; };
 		C386D6D02419975A00699085 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C386D6CF2419975A00699085 /* AppDelegate.swift */; };
 		C386D6D22419975A00699085 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C386D6D12419975A00699085 /* SceneDelegate.swift */; };
 		C386D6D62419975B00699085 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C386D6D52419975B00699085 /* Assets.xcassets */; };
@@ -24,13 +25,12 @@
 		C3A67856241AB8AD005A4681 /* MiscNetworkRequests.m in Sources */ = {isa = PBXBuildFile; fileRef = C3A67855241AB8AD005A4681 /* MiscNetworkRequests.m */; };
 		C3A67858241ADDF7005A4681 /* Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A67857241ADDF7005A4681 /* Commit.swift */; };
 		C3B3760025B8CDA300AD43AB /* Person.m in Sources */ = {isa = PBXBuildFile; fileRef = C3B375FF25B8CDA300AD43AB /* Person.m */; };
-		E211705F801A8167D308F94A /* libPods-FLEXample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BBD699DDBAC5A16D8CFD39AC /* libPods-FLEXample.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		33A4EDAC37AA215CF95EEA24 /* Pods-FLEXample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FLEXample.release.xcconfig"; path = "Target Support Files/Pods-FLEXample/Pods-FLEXample.release.xcconfig"; sourceTree = "<group>"; };
-		57041F764D8B1C098B9B4073 /* Pods-FLEXample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FLEXample.debug.xcconfig"; path = "Target Support Files/Pods-FLEXample/Pods-FLEXample.debug.xcconfig"; sourceTree = "<group>"; };
-		BBD699DDBAC5A16D8CFD39AC /* libPods-FLEXample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FLEXample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		05F97E8666E04B043AC919BA /* Pods-FLEXample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FLEXample.release.xcconfig"; path = "Target Support Files/Pods-FLEXample/Pods-FLEXample.release.xcconfig"; sourceTree = "<group>"; };
+		9FD21AEF548AD7B89327EEFB /* Pods-FLEXample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FLEXample.debug.xcconfig"; path = "Target Support Files/Pods-FLEXample/Pods-FLEXample.debug.xcconfig"; sourceTree = "<group>"; };
+		A5FFDDD9C2278C79FFA0295B /* libPods-FLEXample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FLEXample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C386D6CC2419975A00699085 /* FLEXample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FLEXample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C386D6CF2419975A00699085 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C386D6D12419975A00699085 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -64,13 +64,21 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E211705F801A8167D308F94A /* libPods-FLEXample.a in Frameworks */,
+				7CB8C28DD5EC2AF347FE6AE4 /* libPods-FLEXample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8C3080FE45370D3EC44ADD5D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A5FFDDD9C2278C79FFA0295B /* libPods-FLEXample.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		C386D6C32419975A00699085 = {
 			isa = PBXGroup;
 			children = (
@@ -78,7 +86,7 @@
 				C3A67853241AB88F005A4681 /* Realm */,
 				C386D6CD2419975A00699085 /* Products */,
 				E367791A4E4085CCB945F0F8 /* Pods */,
-				DCEB5037DA3D5C01CB9CEE93 /* Frameworks */,
+				8C3080FE45370D3EC44ADD5D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -161,19 +169,11 @@
 			path = Realm;
 			sourceTree = "<group>";
 		};
-		DCEB5037DA3D5C01CB9CEE93 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BBD699DDBAC5A16D8CFD39AC /* libPods-FLEXample.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		E367791A4E4085CCB945F0F8 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				57041F764D8B1C098B9B4073 /* Pods-FLEXample.debug.xcconfig */,
-				33A4EDAC37AA215CF95EEA24 /* Pods-FLEXample.release.xcconfig */,
+				9FD21AEF548AD7B89327EEFB /* Pods-FLEXample.debug.xcconfig */,
+				05F97E8666E04B043AC919BA /* Pods-FLEXample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -185,7 +185,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C386D6E02419975B00699085 /* Build configuration list for PBXNativeTarget "FLEXample" */;
 			buildPhases = (
-				E25E87A42AA269B0CF1830D1 /* [CP] Check Pods Manifest.lock */,
+				83A4AFDE614DA1561E5608BA /* [CP] Check Pods Manifest.lock */,
 				C386D6C82419975A00699085 /* Sources */,
 				C386D6C92419975A00699085 /* Frameworks */,
 				C386D6CA2419975A00699085 /* Resources */,
@@ -195,6 +195,8 @@
 			dependencies = (
 			);
 			name = FLEXample;
+			packageProductDependencies = (
+			);
 			productName = FLEXample;
 			productReference = C386D6CC2419975A00699085 /* FLEXample.app */;
 			productType = "com.apple.product-type.application";
@@ -224,6 +226,8 @@
 				Base,
 			);
 			mainGroup = C386D6C32419975A00699085;
+			packageReferences = (
+			);
 			productRefGroup = C386D6CD2419975A00699085 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -253,7 +257,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		E25E87A42AA269B0CF1830D1 /* [CP] Check Pods Manifest.lock */ = {
+		83A4AFDE614DA1561E5608BA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -425,7 +429,7 @@
 		};
 		C386D6E12419975B00699085 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 57041F764D8B1C098B9B4073 /* Pods-FLEXample.debug.xcconfig */;
+			baseConfigurationReference = 9FD21AEF548AD7B89327EEFB /* Pods-FLEXample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -450,7 +454,7 @@
 		};
 		C386D6E22419975B00699085 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 33A4EDAC37AA215CF95EEA24 /* Pods-FLEXample.release.xcconfig */;
+			baseConfigurationReference = 05F97E8666E04B043AC919BA /* Pods-FLEXample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/Example/FLEXample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/FLEXample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:FLEXample.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Example/FLEXample/App/CommitListViewController.h
+++ b/Example/FLEXample/App/CommitListViewController.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Flipboard. All rights reserved.
 //
 
-#import "FLEXFilteringTableViewController.h"
+@import FLEX;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Example/FLEXample/Supporting Files/FLEXample-Bridging-Header.h
+++ b/Example/FLEXample/Supporting Files/FLEXample-Bridging-Header.h
@@ -2,7 +2,6 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <FLEX.h>
 #import "MiscNetworkRequests.h"
 #import "CommitListViewController.h"
 #import "Person.h"

--- a/FLEX.podspec
+++ b/FLEX.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |spec|
   spec.platform         = :ios, "9.0"
   spec.source           = { :git => "https://github.com/Flipboard/FLEX.git", :tag => "#{spec.version}" }
   spec.source_files     = "Classes/**/*.{h,c,m,mm}"
+  spec.exclude_files    = "Classes/Headers/*.{h,c,m,mm}"
   spec.frameworks       = [ "Foundation", "UIKit", "CoreGraphics", "ImageIO", "QuartzCore", "WebKit", "Security", "SceneKit" ]
   spec.libraries        = [ "z", "sqlite3" ]
   spec.requires_arc     = true

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,71 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "FLEX",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(name: "FLEX", targets: ["FLEX"])
+    ],
+    targets: [
+        .target(
+            name: "FLEX",
+            path: "Classes",
+            exclude: [
+                "Info.plist",
+                "Utility/APPLE_LICENSE",
+                "Network/PonyDebugger/LICENSE",
+                "GlobalStateExplorers/DatabaseBrowser/LICENSE",
+                "GlobalStateExplorers/Keychain/SSKeychain_LICENSE",
+                "GlobalStateExplorers/SystemLog/LLVM_LICENSE.TXT",
+            ],
+            publicHeadersPath: "Headers",
+            cSettings: [
+                .unsafeFlags([
+                    "-Wno-deprecated-declarations",
+                    "-Wno-strict-prototypes",
+                    "-Wno-unsupported-availability-guard",
+                ]),
+                .headerSearchPath("Classes"),
+                .headerSearchPath("Core"),
+                .headerSearchPath("Core/Controllers"),
+                .headerSearchPath("Core/Views"),
+                .headerSearchPath("Core/Views/Cells"),
+                .headerSearchPath("Core/Views/Carousel"),
+                .headerSearchPath("ObjectExplorers"),
+                .headerSearchPath("ObjectExplorers/Sections"),
+                .headerSearchPath("ObjectExplorers/Sections/Shortcuts"),
+                .headerSearchPath("Network"),
+                .headerSearchPath("Network/PonyDebugger"),
+                .headerSearchPath("Toolbar"),
+                .headerSearchPath("Manager"),
+                .headerSearchPath("Manager/Private"),
+                .headerSearchPath("Editing"),
+                .headerSearchPath("Editing/ArgumentInputViews"),
+                .headerSearchPath("Headers"),
+                .headerSearchPath("ExplorerInterface"),
+                .headerSearchPath("ExplorerInterface/Tabs"),
+                .headerSearchPath("ExplorerInterface/Bookmarks"),
+                .headerSearchPath("GlobalStateExplorers"),
+                .headerSearchPath("GlobalStateExplorers/Globals"),
+                .headerSearchPath("GlobalStateExplorers/Keychain"),
+                .headerSearchPath("GlobalStateExplorers/FileBrowser"),
+                .headerSearchPath("GlobalStateExplorers/SystemLog"),
+                .headerSearchPath("GlobalStateExplorers/DatabaseBrowser"),
+                .headerSearchPath("GlobalStateExplorers/RuntimeBrowser"),
+                .headerSearchPath("GlobalStateExplorers/RuntimeBrowser/DataSources"),
+                .headerSearchPath("ViewHierarchy"),
+                .headerSearchPath("ViewHierarchy/SnapshotExplorer"),
+                .headerSearchPath("ViewHierarchy/SnapshotExplorer/Scene"),
+                .headerSearchPath("ViewHierarchy/TreeExplorer"),
+                .headerSearchPath("Utility"),
+                .headerSearchPath("Utility/Runtime"),
+                .headerSearchPath("Utility/Runtime/Objc"),
+                .headerSearchPath("Utility/Runtime/Objc/Reflection"),
+                .headerSearchPath("Utility/Categories"),
+                .headerSearchPath("Utility/Keyboard")
+            ]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,27 @@ Add the following flags to  to **Other Warnings Flags** in **Build Settings:**
 - `-Wno-strict-prototypes`
 - `-Wno-unsupported-availability-guard`
 
+### Swift Package Manager
+
+Include the dependency in the `depdendencies` value of your `Package.swift`
+
+``` swift
+dependencies: [
+    .package(url: "https://github.com/FLEXTool/FLEX.git", .upToNextMajor(from: "4.3.0"))
+]
+```
+
+Next, include the library in your target:
+
+```js
+.target(
+    name: "YourDependency",
+    dependencies: [
+        "FLEX"
+    ]
+)
+```
+
 ## Excluding FLEX from Release (App Store) Builds
 
 FLEX makes it easy to explore the internals of your app, so it is not something you should expose to your users. Fortunately, it is easy to exclude FLEX files from Release builds. The strategies differ depending on how you integrated FLEX in your project, and are described below.
@@ -197,6 +218,13 @@ pod 'FLEX', :configurations => ['Debug']
 	Finally, add `$(SRCROOT)/Carthage/Build/iOS/FLEX.framework` as input file of this script phase.
 	
 <img width=75% height=75% src=https://user-images.githubusercontent.com/8371943/70274062-0d4b3f80-1771-11ea-94ea-ca7e7b5ca244.jpg>
+
+### Swift Package Manager
+
+In Xcode, navigate to `Build Settings > Build Options > Excluded Source File Names`. For your `Release` configuration, set it to `FLEX.o` like this to exclude all files with the `FLEX` prefix:
+
+<img width=75% height=75% src=https://user-images.githubusercontent.com/1234765/98673373-8545c080-2357-11eb-9587-0743998e23ba.png>
+
 
 ### FLEX files added manually to a project
 

--- a/generate-spm-headers.sh
+++ b/generate-spm-headers.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Link a specific header
+makeheader() {
+    rm "Classes/Headers/$(basename $1)"
+    ln -s "../../$1" "Classes/Headers/$(basename $1)"
+}
+
+# Link all headers under the given path and in subfolders
+generate_headers_recursive() {
+    for path in `find "Classes/$1" -not -path "*Headers*" -name "*.h"`; do
+        makeheader "$path"
+    done
+}
+
+# Link all headers directly under the given path, only
+generate_headers() {
+    for path in `ls "Classes/$1" | grep '\.h'`; do
+        if [[ $1 ]]; then
+            makeheader "Classes/$1/$path"
+        else
+            makeheader "Classes/$path"
+        fi
+    done
+}
+
+# The code below MUST match what is public_header_files in the podspec.
+# When this file was last updated, this was the content of public_header_files:
+#
+#    "Classes/*.h", "Classes/Manager/*.h", "Classes/Toolbar/*.h",
+#    "Classes/GlobalStateExplorers/Globals/FLEXGlobalsEntry.h",
+#    "Classes/Core/**/*.h", "Classes/Utility/Runtime/Objc/**/*.h",
+#    "Classes/ObjectExplorers/**/*.h", "Classes/Editing/**/*.h",
+#    "Classes/Utility/FLEXMacros.h", "Classes/Utility/Categories/*.h",
+#    "Classes/Utility/FLEXAlert.h", "Classes/Utility/FLEXResources.h"
+
+# Include all headers in these folders
+generate_headers "" # Top-level headers
+generate_headers "Manager"
+generate_headers "Toolbar"
+generate_headers "Utility/Categories"
+generate_headers_recursive "Core"
+generate_headers_recursive "Utility/Runtime/Objc"
+generate_headers_recursive "ObjectExplorers"
+generate_headers_recursive "Editing"
+
+# Include only headers in these specific folders,
+# such as those with subfolders that should not be linked
+makeheader "Classes/Utility/FLEXMacros.h"
+makeheader "Classes/Utility/FLEXAlert.h"
+makeheader "Classes/Utility/FLEXResources.h"
+makeheader "Classes/GlobalStateExplorers/Globals/FLEXGlobalsEntry.h"
+
+# Print all folders in Classes for use in Package.swift
+for folder in `find "Classes" -type d`; do
+    echo ".headerSearchPath(\"${folder#Classes/}\"),"
+done


### PR DESCRIPTION
Hi, I add support for swift package manager for this awesome library.

I saw the PR #464 but this contains an error with the functions of extensions (you can't use it).

This PR solve this error and change the README.md for explain how to install with Swift Package Manager.

Bassically the support consist in add a new folder "Headers" with all ".h" headers of the library. This ".h" are a symlink to the reals in other paths and they are generated with the new script `create_headers.sh` in the root repo. The `Package.swift` use this Header folder as public headers of the library. Feel free to add some exceptions in the script if you want some of this ".h" as private headers.

Also, I added a sample target in the project with FLEX installed with Swift Package Manager
