### PR TITLE
Fix Flipboard name leftovers and unify identifier structure

### DIFF
--- a/Classes/ExplorerInterface/FLEXExplorerViewController.m
+++ b/Classes/ExplorerInterface/FLEXExplorerViewController.m
@@ -591,7 +591,7 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
     if (self.currentMode == FLEXExplorerModeSelect && tapGR.state == UIGestureRecognizerStateRecognized) {
         // Note that [tapGR locationInView:nil] is broken in iOS 8,
         // so we have to do a two step conversion to window coordinates.
-        // Thanks to @lascorbe for finding this: https://github.com/Flipboard/FLEX/pull/31
+        // Thanks to @lascorbe for finding this: https://github.com/FLEXTool/FLEX/pull/31
         CGPoint tapPointInView = [tapGR locationInView:self.view];
         CGPoint tapPointInWindow = [self.view convertPoint:tapPointInView toView:nil];
         [self updateOutlineViewsForSelectionPoint:tapPointInWindow];

--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychain.m
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychain.m
@@ -10,7 +10,7 @@
 #import "FLEXKeychain.h"
 #import "FLEXKeychainQuery.h"
 
-NSString * const kFLEXKeychainErrorDomain = @"com.flipboard.flex";
+NSString * const kFLEXKeychainErrorDomain = @"com.FLEX";
 NSString * const kFLEXKeychainAccountKey = @"acct";
 NSString * const kFLEXKeychainCreatedAtKey = @"cdat";
 NSString * const kFLEXKeychainClassKey = @"labl";

--- a/Classes/Network/FLEXNetworkRecorder.m
+++ b/Classes/Network/FLEXNetworkRecorder.m
@@ -18,7 +18,7 @@ NSString *const kFLEXNetworkRecorderTransactionUpdatedNotification = @"kFLEXNetw
 NSString *const kFLEXNetworkRecorderUserInfoTransactionKey = @"transaction";
 NSString *const kFLEXNetworkRecorderTransactionsClearedNotification = @"kFLEXNetworkRecorderTransactionsClearedNotification";
 
-NSString *const kFLEXNetworkRecorderResponseCacheLimitDefaultsKey = @"com.flex.responseCacheLimit";
+NSString *const kFLEXNetworkRecorderResponseCacheLimitDefaultsKey = @"com.FLEX.responseCacheLimit";
 
 @interface FLEXNetworkRecorder ()
 
@@ -48,7 +48,7 @@ NSString *const kFLEXNetworkRecorderResponseCacheLimitDefaultsKey = @"com.flex.r
         self.hostBlacklist = NSUserDefaults.standardUserDefaults.flex_networkHostBlacklist.mutableCopy;
 
         // Serial queue used because we use mutable objects that are not thread safe
-        self.queue = dispatch_queue_create("com.flex.FLEXNetworkRecorder", DISPATCH_QUEUE_SERIAL);
+        self.queue = dispatch_queue_create("com.FLEX.FLEXNetworkRecorder", DISPATCH_QUEUE_SERIAL);
     }
     
     return self;

--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -24,7 +24,7 @@
 #include <dlfcn.h>
 
 NSString *const kFLEXNetworkObserverEnabledStateChangedNotification = @"kFLEXNetworkObserverEnabledStateChangedNotification";
-static NSString *const kFLEXNetworkObserverEnabledDefaultsKey = @"com.flex.FLEXNetworkObserver.enableOnLaunch";
+static NSString *const kFLEXNetworkObserverEnabledDefaultsKey = @"com.FLEX.FLEXNetworkObserver.enableOnLaunch";
 
 typedef void (^NSURLSessionAsyncCompletion)(id fileURLOrData, NSURLResponse *response, NSError *error);
 typedef NSURLSessionTask * (^NSURLSessionNewTaskMethod)(NSURLSession *, id, NSURLSessionAsyncCompletion);
@@ -133,7 +133,7 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask delegate:(id<NSUR
 + (void)sniffWithoutDuplicationForObject:(NSObject *)object selector:(SEL)selector sniffingBlock:(void (^)(void))sniffingBlock originalImplementationBlock:(void (^)(void))originalImplementationBlock {
     // If we don't have an object to detect nested calls on, just run the original implementation and bail.
     // This case can happen if someone besides the URL loading system calls the delegate methods directly.
-    // See https://github.com/Flipboard/FLEX/issues/61 for an example.
+    // See https://github.com/FLEXTool/FLEX/issues/61 for an example.
     if (!object) {
         originalImplementationBlock();
         return;
@@ -1293,7 +1293,7 @@ static char const * const kFLEXRequestIDKey = "kFLEXRequestIDKey";
     if (self) {
         self.requestStatesForRequestIDs = [NSMutableDictionary new];
         self.queue = dispatch_queue_create(
-            "com.flex.FLEXNetworkObserver", DISPATCH_QUEUE_SERIAL
+            "com.FLEX.FLEXNetworkObserver", DISPATCH_QUEUE_SERIAL
         );
     }
     

--- a/Classes/Utility/Categories/NSUserDefaults+FLEX.m
+++ b/Classes/Utility/Categories/NSUserDefaults+FLEX.m
@@ -8,15 +8,15 @@
 
 #import "NSUserDefaults+FLEX.h"
 
-NSString * const kFLEXDefaultsToolbarTopMarginKey = @"com.flex.FLEXToolbar.topMargin";
-NSString * const kFLEXDefaultsiOSPersistentOSLogKey = @"com.flipborad.flex.enable_persistent_os_log";
-NSString * const kFLEXDefaultsHidePropertyIvarsKey = @"com.flipboard.FLEX.hide_property_ivars";
-NSString * const kFLEXDefaultsHidePropertyMethodsKey = @"com.flipboard.FLEX.hide_property_methods";
-NSString * const kFLEXDefaultsHideMethodOverridesKey = @"com.flipboard.FLEX.hide_method_overrides";
-NSString * const kFLEXDefaultsHideVariablePreviewsKey = @"com.flipboard.FLEX.hide_variable_previews";
-NSString * const kFLEXDefaultsNetworkHostBlacklistKey = @"com.flipboard.FLEX.network_host_blacklist";
-NSString * const kFLEXDefaultsDisableOSLogForceASLKey = @"com.flipboard.FLEX.try_disable_os_log";
-NSString * const kFLEXDefaultsRegisterJSONExplorerKey = @"com.flipboard.FLEX.view_json_as_object";
+NSString * const kFLEXDefaultsToolbarTopMarginKey = @"com.FLEX.FLEXToolbar.topMargin";
+NSString * const kFLEXDefaultsiOSPersistentOSLogKey = @"com.FLEX.enable_persistent_os_log";
+NSString * const kFLEXDefaultsHidePropertyIvarsKey = @"com.FLEX.hide_property_ivars";
+NSString * const kFLEXDefaultsHidePropertyMethodsKey = @"com.FLEX.hide_property_methods";
+NSString * const kFLEXDefaultsHideMethodOverridesKey = @"com.FLEX.hide_method_overrides";
+NSString * const kFLEXDefaultsHideVariablePreviewsKey = @"com.FLEX.hide_variable_previews";
+NSString * const kFLEXDefaultsNetworkHostBlacklistKey = @"com.FLEX.network_host_blacklist";
+NSString * const kFLEXDefaultsDisableOSLogForceASLKey = @"com.FLEX.try_disable_os_log";
+NSString * const kFLEXDefaultsRegisterJSONExplorerKey = @"com.FLEX.view_json_as_object";
 
 #define FLEXDefaultsPathForFile(name) ({ \
     NSArray *paths = NSSearchPathForDirectoriesInDomains( \

--- a/Example/FLEXample.xcodeproj/project.pbxproj
+++ b/Example/FLEXample.xcodeproj/project.pbxproj
@@ -433,7 +433,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.flipboard.flex.FLEXample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.FLEX.FLEXample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "FLEXample/Supporting Files/FLEXample-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.flipboard.flex.FLEXample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.FLEX.FLEXample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "FLEXample/Supporting Files/FLEXample-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/Example/FLEXample/App/Commit.swift
+++ b/Example/FLEXample/App/Commit.swift
@@ -3,7 +3,7 @@
 //  FLEXample
 //
 //  Created by Tanner on 3/12/20.
-//  Copyright © 2020 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 import Foundation

--- a/Example/FLEXample/App/CommitListViewController.h
+++ b/Example/FLEXample/App/CommitListViewController.h
@@ -3,7 +3,7 @@
 //  FLEXample
 //
 //  Created by Tanner on 3/11/20.
-//  Copyright © 2020 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 #import "FLEXFilteringTableViewController.h"

--- a/Example/FLEXample/App/CommitListViewController.m
+++ b/Example/FLEXample/App/CommitListViewController.m
@@ -3,7 +3,7 @@
 //  FLEXample
 //
 //  Created by Tanner on 3/11/20.
-//  Copyright © 2020 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 #import "CommitListViewController.h"
@@ -34,7 +34,7 @@
     ];
     
     // Load and process commits
-    NSString *commitsURL = @"https://api.github.com/repos/Flipboard/FLEX/commits";
+    NSString *commitsURL = @"https://api.github.com/repos/FLEXTool/FLEX/commits";
     [self startDataTask:commitsURL completion:^(NSData *data, NSInteger statusCode, NSError *error) {
         if (statusCode == 200) {
             self.commits.list = [Commit commitsFrom:data];

--- a/Example/FLEXample/AppDelegate.swift
+++ b/Example/FLEXample/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  FLEXample
 //
 //  Created by Tanner on 3/11/20.
-//  Copyright © 2020 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 import UIKit

--- a/Example/FLEXample/MiscNetworkRequests.h
+++ b/Example/FLEXample/MiscNetworkRequests.h
@@ -3,7 +3,7 @@
 //  FLEXample
 //
 //  Created by Tanner on 3/12/20.
-//  Copyright © 2020 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Example/FLEXample/MiscNetworkRequests.m
+++ b/Example/FLEXample/MiscNetworkRequests.m
@@ -3,7 +3,7 @@
 //  FLEXample
 //
 //  Created by Tanner on 3/12/20.
-//  Copyright © 2020 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 #import "MiscNetworkRequests.h"
@@ -125,13 +125,13 @@
     // Remaining requests made through NSURLConnection with a delegate
     NSArray *requestURLStrings = @[ @"https://lorempixel.com/400/400/",
                                     @"https://google.com",
-                                    @"https://api.github.com/users/Flipboard/repos",
-                                    @"https://api.github.com/repos/Flipboard/FLEX/issues",
+                                    @"https://api.github.com/users/FLEXTool/repos",
+                                    @"https://api.github.com/repos/FLEXTool/FLEX/issues",
                                     @"https://cloud.githubusercontent.com/assets/516562/3971767/e4e21f58-27d6-11e4-9b07-4d1fe82b80ca.png",
                                     @"https://lorempixel.com/750/1334/" ];
     
     // Async NSURLConnection
-    [NSURLConnection sendAsynchronousRequest:[self request:@"https://api.github.com/repos/Flipboard/FLEX/issues"]
+    [NSURLConnection sendAsynchronousRequest:[self request:@"https://api.github.com/repos/FLEXTool/FLEX/issues"]
         queue:NSOperationQueue.mainQueue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
     }];
     

--- a/Example/FLEXample/SceneDelegate.swift
+++ b/Example/FLEXample/SceneDelegate.swift
@@ -3,7 +3,7 @@
 //  FLEXample
 //
 //  Created by Tanner on 3/11/20.
-//  Copyright © 2020 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 import UIKit

--- a/FLEX.podspec
+++ b/FLEX.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
                         - Dynamically view and modify `NSUserDefaults` values.
                         DESC
 
-  spec.homepage         = "https://github.com/Flipboard/FLEX"
+  spec.homepage         = "https://github.com/FLEXTool/FLEX"
   spec.screenshots      = [ "http://engineering.flipboard.com/assets/flex/basic-view-exploration.gif",
                             "http://engineering.flipboard.com/assets/flex/advanced-view-editing.gif",
                             "http://engineering.flipboard.com/assets/flex/heap-browser.gif",
@@ -30,7 +30,7 @@ Pod::Spec.new do |spec|
   spec.author           = { "Tanner Bennett" => "tannerbennett@me.com" }
   spec.social_media_url = "https://twitter.com/NSExceptional"
   spec.platform         = :ios, "9.0"
-  spec.source           = { :git => "https://github.com/Flipboard/FLEX.git", :tag => "#{spec.version}" }
+  spec.source           = { :git => "https://github.com/FLEXTool/FLEX.git", :tag => "#{spec.version}" }
   spec.source_files     = "Classes/**/*.{h,c,m,mm}"
   spec.frameworks       = [ "Foundation", "UIKit", "CoreGraphics", "ImageIO", "QuartzCore", "WebKit", "Security", "SceneKit" ]
   spec.libraries        = [ "z", "sqlite3" ]

--- a/FLEX.xcodeproj/project.pbxproj
+++ b/FLEX.xcodeproj/project.pbxproj
@@ -1894,7 +1894,7 @@
 				INFOPLIST_FILE = FLEXTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.flipboard.FLEXTestsMethodsList;
+				PRODUCT_BUNDLE_IDENTIFIER = com.FLEX.FLEXTestsMethodsList;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1910,7 +1910,7 @@
 				INFOPLIST_FILE = FLEXTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.flipboard.FLEXTestsMethodsList;
+				PRODUCT_BUNDLE_IDENTIFIER = com.FLEX.FLEXTestsMethodsList;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -2055,7 +2055,7 @@
 				INSTALL_PATH = "@rpath";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.flipboard.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.FLEX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -2088,7 +2088,7 @@
 				INSTALL_PATH = "@rpath";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.flipboard.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.FLEX;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;

--- a/FLEXTests/FLEXTests.m
+++ b/FLEXTests/FLEXTests.m
@@ -3,7 +3,7 @@
 //  FLEXTests
 //
 //  Created by Tanner Bennett on 8/27/19.
-//  Copyright © 2019 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/FLEXTests/FLEXTestsMethodsList.m
+++ b/FLEXTests/FLEXTestsMethodsList.m
@@ -3,7 +3,7 @@
 //  FLEXTestMethodList
 //
 //  Created by Tigran Yesayan on 7/6/17.
-//  Copyright © 2017 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/FLEXTests/FLEXTypeEncodingParserTests.m
+++ b/FLEXTests/FLEXTypeEncodingParserTests.m
@@ -3,7 +3,7 @@
 //  FLEXTests
 //
 //  Created by Tanner Bennett on 8/25/19.
-//  Copyright © 2019 Flipboard. All rights reserved.
+//  Copyright © 2020 FLEX Team. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2016, Flipboard
+Copyright (c) 2014-2020, FLEX Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@ are permitted provided that the following conditions are met:
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
 
-* Neither the name of Flipboard nor the names of its
+* Neither the name of copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FLEX
 [![CocoaPods](https://img.shields.io/cocoapods/v/FLEX.svg)](https://cocoapods.org/?q=FLEX)
- [![CocoaPods](https://img.shields.io/cocoapods/l/FLEX.svg)](https://github.com/Flipboard/FLEX/blob/master/LICENSE)
+ [![CocoaPods](https://img.shields.io/cocoapods/l/FLEX.svg)](https://github.com/FLEXTool/FLEX/blob/master/LICENSE)
  [![CocoaPods](https://img.shields.io/cocoapods/p/FLEX.svg)]()
  [![Twitter: @ryanolsonk](https://img.shields.io/badge/contact-@ryanolsonk-blue.svg?style=flat)](https://twitter.com/ryanolsonk)
  [![Build Status](https://travis-ci.org/Flipboard/FLEX.svg?branch=master)](https://travis-ci.org/Flipboard/FLEX)
@@ -145,7 +145,7 @@ pod 'FLEX', :configurations => ['Debug']
 Add the following to your Cartfile:
 
 ```
-github "flipboard/FLEX"
+github "FLEXTool/FLEX"
 ```
 
 ### Buck
@@ -158,7 +158,7 @@ Manually add the files in `Classes/` to your Xcode project, or just drag in the 
 
 ##### Silencing warnings
 
-Add the following flags to  to **Other Warnings Flags** in **Build Settings:** 
+Add the following flags to  to **Other Warnings Flags** in **Build Settings:**
 
 - `-Wno-deprecated-declarations`
 - `-Wno-strict-prototypes`
@@ -181,7 +181,7 @@ pod 'FLEX', :configurations => ['Debug']
 ### Carthage
 
 1. Do NOT add `FLEX.framework` to the embedded binaries of your target, as it would otherwise be included in all builds (therefore also in release ones).
-1. Instead, add `$(PROJECT_DIR)/Carthage/Build/iOS` to your target _Framework Search Paths_ (this setting might already be present if you already included other frameworks with Carthage). This makes it possible to import the FLEX framework from your source files. It does not harm if this setting is added for all configurations, but it should at least be added for the debug one. 
+1. Instead, add `$(PROJECT_DIR)/Carthage/Build/iOS` to your target _Framework Search Paths_ (this setting might already be present if you already included other frameworks with Carthage). This makes it possible to import the FLEX framework from your source files. It does not harm if this setting is added for all configurations, but it should at least be added for the debug one.
 1. Add a _Run Script Phase_ to your target (inserting it after the existing `Link Binary with Libraries` phase, for example), and which will embed `FLEX.framework` in debug builds only:
 
 	```shell
@@ -189,9 +189,9 @@ pod 'FLEX', :configurations => ['Debug']
 	  /usr/local/bin/carthage copy-frameworks
 	fi
 	```
-	
+
 	Finally, add `$(SRCROOT)/Carthage/Build/iOS/FLEX.framework` as input file of this script phase.
-	
+
 <img width=75% height=75% src=https://user-images.githubusercontent.com/8371943/70274062-0d4b3f80-1771-11ea-94ea-ca7e7b5ca244.jpg>
 
 ### FLEX files added manually to a project
@@ -227,7 +227,7 @@ FLEX builds on ideas and inspiration from open source tools that came before it.
 
 
 ## Contributing
-Please see our [Contributing Guide](https://github.com/Flipboard/FLEX/blob/master/CONTRIBUTING.md).
+Please see our [Contributing Guide](https://github.com/FLEXTool/FLEX/blob/master/CONTRIBUTING.md).
 
 
 ## TODO


### PR DESCRIPTION
I found there are some leftovers since we moved the project to `FLEXTool`, so I fixed most of them here.

Some of them are used in the identifiers, so I think it would be a good idea to unify them by using `com.FLEX` for all occurrences. However, I don't feel strongly about this so let me know if there is a better one we prefer.