### PR TITLE
Fix view controller preview image issue

### DIFF
--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXLayerShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXLayerShortcuts.m
@@ -15,11 +15,11 @@
 + (instancetype)forObject:(CALayer *)layer {
     return [self forObject:layer additionalRows:@[
         [FLEXActionShortcut title:@"Preview Image" subtitle:nil
-            viewer:^UIViewController *(id layer) {
+            viewer:^UIViewController *(CALayer *layer) {
                 return [FLEXImagePreviewViewController previewForLayer:layer];
             }
-            accessoryType:^UITableViewCellAccessoryType(id layer) {
-                return UITableViewCellAccessoryDisclosureIndicator;
+            accessoryType:^UITableViewCellAccessoryType(CALayer *layer) {
+                return CGRectIsEmpty(layer.bounds) ? 0 : UITableViewCellAccessoryDisclosureIndicator;
             }
         ]
     ]];

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
@@ -74,7 +74,7 @@
             }
         ],
         [FLEXActionShortcut title:@"Preview Image" subtitle:^NSString *(UIView *view) {
-                return !CGRectIsEmpty(view.bounds) ? @"" : @"Unavailable because view.bounds is CGRectZero";
+                return !CGRectIsEmpty(view.bounds) ? @"" : @"Unavailable with empty bounds";
             }
             viewer:^UIViewController *(UIView *view) {
                 return [FLEXImagePreviewViewController previewForView:view];

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
@@ -73,13 +73,15 @@
                 return controller ? UITableViewCellAccessoryDisclosureIndicator : 0;
             }
         ],
-        [FLEXActionShortcut title:@"Preview Image" subtitle:nil
-            viewer:^UIViewController *(id view) {
+        [FLEXActionShortcut title:@"Preview Image" subtitle:^NSString *(UIView *view) {
+                return !CGRectIsEmpty(view.bounds) ? @"" : @"Unavailable because view.bounds is CGRectZero";
+            }
+            viewer:^UIViewController *(UIView *view) {
                 return [FLEXImagePreviewViewController previewForView:view];
             }
             accessoryType:^UITableViewCellAccessoryType(UIView *view) {
                 // Disable preview if bounds are CGRectZero
-                return CGRectIsEmpty(view.bounds) ? UITableViewCellAccessoryDisclosureIndicator : 0;
+                return !CGRectIsEmpty(view.bounds) ? UITableViewCellAccessoryDisclosureIndicator : 0;
             }
         ]
     ]];


### PR DESCRIPTION
This issue was introduced in https://github.com/FLEXTool/FLEX/commit/547bfbaec0c0910ee4c135722ff02c27d93826b6, there is a `!` missed in the boolean check, so fixing it here.

I also consolidated some logic around this, also apply the same thing to the `CALayer` as well.