### PR TITLE
Add ability to toggle background colors for image previews

### DIFF
--- a/Classes/ExplorerInterface/FLEXExplorerViewController.m
+++ b/Classes/ExplorerInterface/FLEXExplorerViewController.m
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
 @property (nonatomic) UIView *selectedViewOverlay;
 
 /// Used to actuate changes in view selection on iOS 10+
-@property (nonatomic, readonly) UISelectionFeedbackGenerator *selectionFBG;
+@property (nonatomic, readonly) UISelectionFeedbackGenerator *selectionFBG API_AVAILABLE(ios(10.0));
 
 /// self.view.window as a \c FLEXWindow
 @property (nonatomic, readonly) FLEXWindow *window;
@@ -655,7 +655,9 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
 }
 
 - (void)actuateSelectionChangedFeedback {
-    [self.selectionFBG selectionChanged];
+    if (@available(iOS 10.0, *)) {
+        [self.selectionFBG selectionChanged];
+    }
 }
 
 - (void)updateOutlineViewsForSelectionPoint:(CGPoint)selectionPointInWindow {

--- a/Classes/Utility/FLEXResources.h
+++ b/Classes/Utility/FLEXResources.h
@@ -52,7 +52,8 @@
 
 #pragma mark - Misc Icons
 
-@property(readonly, class) UIImage *checkerPattern;
-@property(readonly, class) UIImage *hierarchyIndentPattern;
+@property (readonly, class) UIImage *checkerPattern;
+@property (readonly, class) UIColor *checkerPatternColor;
+@property (readonly, class) UIImage *hierarchyIndentPattern;
 
 @end

--- a/Classes/Utility/FLEXResources.m
+++ b/Classes/Utility/FLEXResources.m
@@ -8838,6 +8838,10 @@ static const u_int8_t FLEXHierarchyIndentPattern3x[] = {
     return FLEXImage(FLEXCheckerPattern);
 }
 
++ (UIColor *)checkerPatternColor {
+    return [UIColor colorWithPatternImage:FLEXResources.checkerPattern];
+}
+
 + (UIImage *)hierarchyIndentPattern {
     return FLEXImageTemplate(FLEXHierarchyIndentPattern);
 }

--- a/Classes/ViewHierarchy/FLEXImagePreviewViewController.m
+++ b/Classes/ViewHierarchy/FLEXImagePreviewViewController.m
@@ -15,6 +15,9 @@
 @property (nonatomic) UIImage *image;
 @property (nonatomic) UIScrollView *scrollView;
 @property (nonatomic) UIImageView *imageView;
+@property (nonatomic) UITapGestureRecognizer *bgColorTapGesture;
+@property (nonatomic) NSInteger backgroundColorIndex;
+@property (nonatomic, readonly) NSArray<UIColor *> *backgroundColors;
 @end
 
 #pragma mark -
@@ -41,7 +44,9 @@
     if (self) {
         self.title = @"Preview";
         self.image = image;
+        _backgroundColors = @[FLEXResources.checkerPatternColor, UIColor.whiteColor, UIColor.blackColor];
     }
+    
     return self;
 }
 
@@ -51,12 +56,10 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.view.backgroundColor = [UIColor colorWithPatternImage:FLEXResources.checkerPattern];
-    
     self.imageView = [[UIImageView alloc] initWithImage:self.image];
     self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
     self.scrollView.delegate = self;
-    self.scrollView.backgroundColor = self.view.backgroundColor;
+    self.scrollView.backgroundColor = self.backgroundColors.firstObject;
     self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.scrollView addSubview:self.imageView];
     self.scrollView.contentSize = self.imageView.frame.size;
@@ -64,7 +67,14 @@
     self.scrollView.maximumZoomScale = 2.0;
     [self.view addSubview:self.scrollView];
     
-    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(actionButtonPressed:)];
+    self.bgColorTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(changeBackground)];
+    [self.scrollView addGestureRecognizer:self.bgColorTapGesture];
+    
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc]
+        initWithBarButtonSystemItem:UIBarButtonSystemItemAction
+        target:self
+        action:@selector(actionButtonPressed:)
+    ];
 }
 
 - (void)viewDidLayoutSubviews {
@@ -95,6 +105,12 @@
         verticalInset = (self.scrollView.bounds.size.height - self.scrollView.contentSize.height) / 2.0;
     }
     self.scrollView.contentInset = UIEdgeInsetsMake(verticalInset, horizontalInset, verticalInset, horizontalInset);
+}
+
+- (void)changeBackground {
+    self.backgroundColorIndex++;
+    self.backgroundColorIndex %= self.backgroundColors.count;
+    self.scrollView.backgroundColor = self.backgroundColors[self.backgroundColorIndex];
 }
 
 - (void)actionButtonPressed:(id)sender {


### PR DESCRIPTION
The default pattern background doesn't work well for some of the transparent images, adding this tap to toggle gesture can greatly improve the usability.

The 3 colors combination should work pretty well for most of the cases.

<img width="20%" src="https://user-images.githubusercontent.com/627231/102153496-30043f80-3e2c-11eb-8111-694f5bc80b4e.gif">
