### PR TITLE
Fix navbar buttons tap handling

### DIFF
--- a/Classes/Core/Controllers/FLEXNavigationController.m
+++ b/Classes/Core/Controllers/FLEXNavigationController.m
@@ -36,10 +36,13 @@
     self.waitingToAddTab = YES;
     
     // Add gesture to reveal toolbar if hidden
-    self.navigationBar.userInteractionEnabled = YES;
-    [self.navigationBar addGestureRecognizer:[[UITapGestureRecognizer alloc]
+    UITapGestureRecognizer *navbarTapGesture = [[UITapGestureRecognizer alloc]
         initWithTarget:self action:@selector(handleNavigationBarTap:)
-    ]];
+    ];
+    
+    // Don't cancel touches to work around bug on versions of iOS prior to 13
+    navbarTapGesture.cancelsTouchesInView = NO;
+    [self.navigationBar addGestureRecognizer:navbarTapGesture];
     
     // Add gesture to dismiss if not presented with a sheet style
     if (@available(iOS 13, *)) {


### PR DESCRIPTION
Navigation bar buttons didn't work on iOS 11-12. The bug was reproduced only on a real device.

Tested on:
- iPhone 6 Plus, iOS 11.0.3
- iPhone 11 Pro, iOS 14.2