### PR TITLE
Fix a build issue caused by changes in FLEXObjectListViewController

### DIFF
--- a/Classes/GlobalStateExplorers/FLEXObjectListViewController.m
+++ b/Classes/GlobalStateExplorers/FLEXObjectListViewController.m
@@ -29,20 +29,12 @@ typedef NS_ENUM(NSUInteger, FLEXObjectReferenceSection) {
     FLEXObjectReferenceSectionCount
 };
 
-NSArray<NSString *> * FLEXObjectReferenceSectionTitles() {
-    return @[
-        @"", @"AutoLayout", @"Key-Value Observing", @"FLEX"
-    ];
-}
-
-NSString const * FLEXTitleForObjectReferenceSection(FLEXObjectReferenceSection section) {
-    switch (section) {
-        case FLEXObjectReferenceSectionCount: @throw NSInternalInconsistencyException;
-        default: return FLEXObjectReferenceSectionTitles()[section];
-    }
-}
-
 @interface FLEXObjectListViewController ()
+
+@property (nonatomic, readonly, class) NSArray<NSPredicate *> *defaultPredicates;
+@property (nonatomic, readonly, class) NSArray<NSString *> *defaultSectionTitles;
+
+
 @property (nonatomic, copy) NSArray<FLEXMutableListSection *> *sections;
 @property (nonatomic, copy) NSArray<FLEXMutableListSection *> *allSections;
 
@@ -119,6 +111,12 @@ NSString const * FLEXTitleForObjectReferenceSection(FLEXObjectReferenceSection s
     return [NSArray flex_forEachUpTo:FLEXObjectReferenceSectionCount map:^id(NSUInteger i) {
         return [self defaultPredicateForSection:i];
     }];
+}
+
++ (NSArray<NSString *> *)defaultSectionTitles {
+    return @[
+        @"", @"AutoLayout", @"Key-Value Observing", @"FLEX"
+    ];
 }
 
 
@@ -220,12 +218,10 @@ NSString const * FLEXTitleForObjectReferenceSection(FLEXObjectReferenceSection s
         }
     }];
 
-    NSArray<NSPredicate *> *predicates = [self defaultPredicates];
-    NSArray<NSString *> *sectionTitles = FLEXObjectReferenceSectionTitles();
     FLEXObjectListViewController *viewController = [[self alloc]
         initWithReferences:instances
-        predicates:predicates
-        sectionTitles:sectionTitles
+        predicates:self.defaultPredicates
+        sectionTitles:self.defaultSectionTitles
     ];
     viewController.title = [NSString stringWithFormat:@"Referencing %@ %p",
         [FLEXRuntimeUtility safeClassNameForObject:object], object


### PR DESCRIPTION
Fix build issue caused by changes in `FLEXObjectListViewController`.

Some changes were added in https://github.com/FLEXTool/FLEX/commit/e63ea4bbfff4200e4d371b1fd86448975162898d, it works fine by default, but if some advanced compile flags were enabled, it will start failing.

So here we added the missing `static` descriptor and removed an unused function.