### PR TITLE
Don't show toolbar by tap on UIControl in UINavigationBar

### DIFF
--- a/Classes/Core/Controllers/FLEXNavigationController.m
+++ b/Classes/Core/Controllers/FLEXNavigationController.m
@@ -148,9 +148,9 @@
 }
      
 - (void)handleNavigationBarTap:(UIGestureRecognizer *)sender {
+    // Don't reveal the toolbar if we were just tapping a button
     CGPoint location = [sender locationInView:self.navigationBar];
     UIView *hitView = [self.navigationBar hitTest:location withEvent:nil];
-
     if ([hitView isKindOfClass:[UIControl class]]) {
         return;
     }

--- a/Classes/Core/Controllers/FLEXNavigationController.m
+++ b/Classes/Core/Controllers/FLEXNavigationController.m
@@ -148,6 +148,13 @@
 }
      
 - (void)handleNavigationBarTap:(UIGestureRecognizer *)sender {
+    CGPoint location = [sender locationInView:self.navigationBar];
+    UIView *hitView = [self.navigationBar hitTest:location withEvent:nil];
+
+    if ([hitView isKindOfClass:[UIControl class]]) {
+        return;
+    }
+
     if (sender.state == UIGestureRecognizerStateRecognized) {
         if (self.toolbarHidden) {
             [self setToolbarHidden:NO animated:YES];


### PR DESCRIPTION
When I use swipe-to-back gesture, the toolbar does not appear, but when I use the Back button, the toolbar appears (see video).
Pull request fixes this issue. Tapping the navigation bar (not including the controls) still shows the toolbar.

https://user-images.githubusercontent.com/22199708/110830399-3a5a9c00-82aa-11eb-90b4-5e9f157c8e55.MP4

