### PR TITLE
Fix: Correctly quote table names

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
@@ -114,9 +114,7 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
 }
 
 - (NSArray<NSArray *> *)queryAllDataInTable:(NSString *)tableName {
-    return [self executeStatement:[@"SELECT * FROM "
-        stringByAppendingString:tableName
-    ]].rows ?: @[];
+    return [self executeStatement:[NSString stringWithFormat:@"SELECT * FROM \"%@\"", tableName]].rows ?: @[];
 }
 
 - (FLEXSQLResult *)executeStatement:(NSString *)sql {

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
@@ -114,7 +114,8 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
 }
 
 - (NSArray<NSArray *> *)queryAllDataInTable:(NSString *)tableName {
-    return [self executeStatement:[NSString stringWithFormat:@"SELECT * FROM \"%@\"", tableName]].rows ?: @[];
+    NSString *command = [NSString stringWithFormat:@"SELECT * FROM \"%@\"", tableName];
+    return [self executeStatement:command].rows ?: @[];
 }
 
 - (FLEXSQLResult *)executeStatement:(NSString *)sql {


### PR DESCRIPTION
Sqlite is often smart enough to not need quotes for identifiers, unless you want to use a keyword as a name. Then you need to quote it

https://www.sqlite.org/lang_keywords.html

Fixes #524