### PR TITLE
Display access group for keychain items

### DIFF
--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychain.h
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychain.h
@@ -34,6 +34,9 @@ extern NSString *const kFLEXKeychainClassKey;
 /// Item description.
 extern NSString *const kFLEXKeychainDescriptionKey;
 
+/// Item group.
+extern NSString *const kFLEXKeychainGroupKey;
+
 /// Item label.
 extern NSString *const kFLEXKeychainLabelKey;
 

--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychain.m
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychain.m
@@ -15,6 +15,7 @@ NSString * const kFLEXKeychainAccountKey = @"acct";
 NSString * const kFLEXKeychainCreatedAtKey = @"cdat";
 NSString * const kFLEXKeychainClassKey = @"labl";
 NSString * const kFLEXKeychainDescriptionKey = @"desc";
+NSString * const kFLEXKeychainGroupKey = @"agrp";
 NSString * const kFLEXKeychainLabelKey = @"labl";
 NSString * const kFLEXKeychainLastModifiedKey = @"mdat";
 NSString * const kFLEXKeychainWhereKey = @"svce";

--- a/Classes/GlobalStateExplorers/Keychain/FLEXKeychainViewController.m
+++ b/Classes/GlobalStateExplorers/Keychain/FLEXKeychainViewController.m
@@ -101,6 +101,7 @@
     FLEXKeychainQuery *query = [FLEXKeychainQuery new];
     query.service = item[kFLEXKeychainWhereKey];
     query.account = item[kFLEXKeychainAccountKey];
+    query.accessGroup = item[kFLEXKeychainGroupKey];
     [query fetch:nil];
 
     return query;
@@ -232,6 +233,7 @@
         make.message(@"Service: ").message(query.service);
         make.message(@"\nAccount: ").message(query.account);
         make.message(@"\nPassword: ").message(query.password);
+        make.message(@"\nGroup: ").message(query.accessGroup);
 
         make.button(@"Copy Service").handler(^(NSArray<NSString *> *strings) {
             [UIPasteboard.generalPasteboard flex_copy:query.service];


### PR DESCRIPTION
As the title says. This piece of information is useful especially when debugging keychain data sharing between same-vendor apps or extensions.