### PR TITLE
Fixed the frame error when showing FLEX for the first time

### DIFF
--- a/Classes/Manager/FLEXManager.m
+++ b/Classes/Manager/FLEXManager.m
@@ -73,7 +73,7 @@
     if (@available(iOS 13.0, *)) {
         // Only look for a new scene if we don't have one
         if (!flex.windowScene) {
-            flex.windowScene = FLEXUtility.activeScene;
+            flex.windowScene = FLEXUtility.appKeyWindow.windowScene;
         }
     }
 #endif
@@ -85,7 +85,11 @@
 
 - (void)toggleExplorer {
     if (self.explorerWindow.isHidden) {
-        [self showExplorer];
+        if (@available(iOS 13.0, *)) {
+            [self showExplorerFromScene:FLEXUtility.appKeyWindow.windowScene];
+        } else {
+            [self showExplorer];
+        }
     } else {
         [self hideExplorer];
     }

--- a/Classes/Manager/FLEXManager.m
+++ b/Classes/Manager/FLEXManager.m
@@ -49,7 +49,7 @@
     NSAssert(NSThread.isMainThread, @"You must use %@ from the main thread only.", NSStringFromClass([self class]));
     
     if (!_explorerWindow) {
-        _explorerWindow = [[FLEXWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+        _explorerWindow = [[FLEXWindow alloc] initWithFrame:FLEXUtility.appKeyWindow.bounds];
         _explorerWindow.eventDelegate = self;
         _explorerWindow.rootViewController = self.explorerViewController;
     }

--- a/Example/FLEXample/Supporting Files/Info.plist
+++ b/Example/FLEXample/Supporting Files/Info.plist
@@ -30,7 +30,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
 			<key>UIWindowSceneSessionRoleApplication</key>


### PR DESCRIPTION
When showing FLEX for the first time when the app is in split view (not in full screen) on iPad, FLEX will layout itself as the width of the whole screen:

(you may need to disabled the auto-opening FLEX code in `SceneDelegate.swift` in FLEXample project to reproduce this case)

![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2021-04-18 at 20 32 56](https://user-images.githubusercontent.com/46736350/115147031-adb2b300-a08b-11eb-859b-dc9633636b3f.png)

This pr fixed this bug.

BTW, I'm not familiar with objc, so feel free to edit this pr if needed~