### PR TITLE
Add a toolbar button to delete all records in a table

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.h
@@ -7,10 +7,19 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "FLEXDatabaseManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface FLEXTableContentViewController : UIViewController
 
+/// Display a table with the given columns, rows, and name.
+/// @param databaseManager an optional manager to allow modifying the table.
 + (instancetype)columns:(NSArray<NSString *> *)columnNames
-                   rows:(NSArray<NSArray<NSString *> *> *)rowData;
+                   rows:(NSArray<NSArray<NSString *> *> *)rowData
+              tableName:(NSString *)tableName
+               database:(_Nullable id<FLEXDatabaseManager>)databaseManager;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableListViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableListViewController.m
@@ -14,6 +14,7 @@
 #import "FLEXMutableListSection.h"
 #import "NSArray+FLEX.h"
 #import "FLEXAlert.h"
+#import "FLEXMacros.h"
 
 @interface FLEXTableListViewController ()
 @property (nonatomic, readonly) id<FLEXDatabaseManager> dbm;
@@ -70,9 +71,9 @@
     self.tables.selectionHandler = ^(FLEXTableListViewController *host, NSString *tableName) {
         NSArray *rows = [host.dbm queryAllDataInTable:tableName];
         NSArray *columns = [host.dbm queryAllColumnsOfTable:tableName];
-        
-        UIViewController *resultsScreen = [FLEXTableContentViewController columns:columns rows:rows];
-        resultsScreen.title = tableName;
+        UIViewController *resultsScreen = [FLEXTableContentViewController
+            columns:columns rows:rows tableName:tableName database:host.dbm
+        ];
         [host.navigationController pushViewController:resultsScreen animated:YES];
     };
     
@@ -100,7 +101,7 @@
                 [FLEXAlert showAlert:@"Message" message:result.message from:self];
             } else {
                 UIViewController *resultsScreen = [FLEXTableContentViewController
-                    columns:result.columns rows:result.rows
+                    columns:result.columns rows:result.rows tableName:@"" database:nil
                 ];
                 
                 [self.navigationController pushViewController:resultsScreen animated:YES];


### PR DESCRIPTION
**Problem:**

At some cases, we need to delete all records in a table to replicate a specific scenario. The only way to do this right now is to run SQL query from tables list. 

**This PR:**

Adds a toolbar button when you open a table to delete all records. Now it's easier than writing a SQL query.

WIP: Add an option to delete a specific row.


https://user-images.githubusercontent.com/1477248/125656863-b51e1af1-7461-4265-bbd5-d42792535572.mp4

