### PR TITLE
Update project.pbxproj to fix crash on launch.

### DIFF
--- a/FLEX.xcodeproj/project.pbxproj
+++ b/FLEX.xcodeproj/project.pbxproj
@@ -2093,11 +2093,13 @@
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+                DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = Classes/Info.plist;
+                INSTALL_PATH = "@rpath";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.flipboard.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2128,11 +2130,13 @@
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+                DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = Classes/Info.plist;
+                INSTALL_PATH = "@rpath";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.flipboard.$(PRODUCT_NAME:rfc1034identifier)";


### PR DESCRIPTION
This reverts some changes in fix #514 that breaks FLEX when it is built with Xcode 12 and 13. Since this change I was getting when running an app linked to FLEX.framework.
```
dyld[4587]: Library not loaded: /Library/Frameworks/FLEX.framework/FLEX
  Referenced from: /private/var/containers/Bundle/Application/redacted/redacted.app/redacted
  Reason: tried: '/Library/Frameworks/FLEX.framework/FLEX' (no such file), '/System/Library/Frameworks/FLEX.framework/FLEX' (no such file)
Library not loaded: /Library/Frameworks/FLEX.framework/FLEX
  Referenced from: /private/var/containers/Bundle/Application//redacted/redacted.app/redacted
  Reason: tried: '/Library/Frameworks/FLEX.framework/FLEX' (no such file), '/System/Library/Frameworks/FLEX.framework/FLEX' (no such file)
(lldb) 
```