### PR TITLE
Add availability check for iOS 11+ SFSafariViewController properties

### DIFF
--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXShortcutsFactory+Defaults.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXShortcutsFactory+Defaults.m
@@ -377,11 +377,16 @@
     
     if (SafariVC) {
         self.append.properties(@[
-            @"delegate", @"configuration", @"dismissButtonStyle"
+            @"delegate"
         ]).forClass(SafariVC);
         if (@available(iOS 10.0, *)) {
             self.append.properties(@[
                 @"preferredBarTintColor", @"preferredControlTintColor"
+            ]).forClass(SafariVC);
+        }
+        if (@available(iOS 11.0, *)) {
+            self.append.properties(@[
+                @"configuration", @"dismissButtonStyle"
             ]).forClass(SafariVC);
         }
     }


### PR DESCRIPTION
Add availability check for iOS 11+ SFSafariViewController properties.

The [`configuration`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller/configuration) and [`dismissButtonStyle`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller/dismissButtonStyle) properties are both iOS 11+ only. They were added in https://github.com/FLEXTool/FLEX/commit/bbaa85bdbffe2b42cf06cbda43f5ec6393ce99a9. Let's add availability check to make sure there is no runtime assertion on certain OS versions.

The error I got was:
```
NSInternalInconsistencyException at +[FLEXProperty named:onClass:] in FLEXProperty.m:49: Cannot find property with name configuration on class SFSafariViewController
```