### PR TITLE
Fix SQLite database viewer

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDatabaseManager.h
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXDatabaseManager.h
@@ -30,6 +30,7 @@
 @optional
 
 - (NSArray<NSString *> *)queryRowIDsInTable:(NSString *)tableName;
+- (FLEXSQLResult *)queryTable:(NSString *)tableName;
 - (FLEXSQLResult *)executeStatement:(NSString *)SQLStatement;
 
 @end

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
@@ -32,7 +32,7 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
     if (self) {
         self.path = path;
     }
-    
+
     return self;
 }
 
@@ -44,7 +44,7 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
     if (self.db) {
         return YES;
     }
-    
+
     int err = sqlite3_open(self.path.UTF8String, &_db);
 
 #if SQLITE_HAS_CODEC
@@ -58,18 +58,18 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
     if (err != SQLITE_OK) {
         return [self storeErrorForLastTask:@"Open"];
     }
-    
+
     return YES;
 }
-    
+
 - (BOOL)close {
     if (!self.db) {
         return YES;
     }
-    
+
     int  rc;
     BOOL retry, triedFinalizingOpenStatements = NO;
-    
+
     do {
         retry = NO;
         rc    = sqlite3_close(_db);
@@ -89,7 +89,7 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
             return NO;
         }
     } while (retry);
-    
+
     self.db = nil;
     return YES;
 }
@@ -121,10 +121,15 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
 - (NSArray<NSString *> *)queryRowIDsInTable:(NSString *)tableName {
     NSString *command = [NSString stringWithFormat:@"SELECT rowid FROM \"%@\"", tableName];
     NSArray<NSArray<NSString *> *> *data = [self executeStatement:command].rows ?: @[];
-    
+
     return [data flex_mapped:^id(NSArray<NSString *> *obj, NSUInteger idx) {
         return obj.firstObject;
     }];
+}
+
+- (FLEXSQLResult *)queryTable:(NSString *)tableName {
+    NSString *command = [NSString stringWithFormat:@"SELECT * FROM \"%@\"", tableName];
+    return [self executeStatement:command];
 }
 
 - (FLEXSQLResult *)executeStatement:(NSString *)sql {
@@ -133,25 +138,25 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
 
 - (FLEXSQLResult *)executeStatement:(NSString *)sql arguments:(NSDictionary *)args {
     [self open];
-    
+
     FLEXSQLResult *result = nil;
-    
+
     sqlite3_stmt *pstmt;
     int status;
     if ((status = sqlite3_prepare_v2(_db, sql.UTF8String, -1, &pstmt, 0)) == SQLITE_OK) {
         NSMutableArray<NSArray *> *rows = [NSMutableArray new];
-        
+
         // Bind parameters, if any
         if (![self bindParameters:args toStatement:pstmt]) {
             return self.lastResult;
         }
-        
+
         // Grab columns
         int columnCount = sqlite3_column_count(pstmt);
         NSArray<NSString *> *columns = [NSArray flex_forEachUpTo:columnCount map:^id(NSUInteger i) {
             return @(sqlite3_column_name(pstmt, (int)i));
         }];
-        
+
         // Execute statement
         while ((status = sqlite3_step(pstmt)) == SQLITE_ROW) {
             // Grab rows if this is a selection query
@@ -162,7 +167,7 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
                 }]];
             }
         }
-        
+
         if (status == SQLITE_DONE) {
             if (rows.count) {
                 // We selected some rows
@@ -181,7 +186,7 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
         // An error occurred creating the prepared statement
         result = _lastResult = [self errorResult:@"Prepared statement"];
     }
-    
+
     sqlite3_finalize(pstmt);
     return result;
 }
@@ -194,12 +199,12 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
     for (NSString *param in args.allKeys) {
         int status = SQLITE_OK, idx = sqlite3_bind_parameter_index(pstmt, param.UTF8String);
         id value = args[param];
-        
+
         if (idx == 0) {
             // No parameter matching that arg
             @throw NSInternalInconsistencyException;
         }
-        
+
         // Null
         if ([value isKindOfClass:[NSNull class]]) {
             status = sqlite3_bind_null(pstmt, idx);
@@ -231,12 +236,12 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
                 case FLEXTypeEncodingUnsignedLongLong:
                     status = sqlite3_bind_int64(pstmt, idx, (sqlite3_int64)[value longValue]);
                     break;
-                
+
                 case FLEXTypeEncodingFloat:
                 case FLEXTypeEncodingDouble:
                     status = sqlite3_bind_double(pstmt, idx, [value doubleValue]);
                     break;
-                    
+
                 default:
                     @throw NSInternalInconsistencyException;
                     break;
@@ -246,14 +251,14 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
         else {
             @throw NSInternalInconsistencyException;
         }
-        
+
         if (status != SQLITE_OK) {
             return [self storeErrorForLastTask:
                 [NSString stringWithFormat:@"Binding param named '%@'", param]
             ];
         }
     }
-    
+
     return YES;
 }
 
@@ -267,34 +272,34 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
     NSString *message = error ? @(error) : [NSString
         stringWithFormat:@"(%@: empty error)", description
     ];
-    
+
     return [FLEXSQLResult error:message];
 }
 
 - (id)objectForColumnIndex:(int)columnIdx stmt:(sqlite3_stmt*)stmt {
     int columnType = sqlite3_column_type(stmt, columnIdx);
-    
+
     switch (columnType) {
         case SQLITE_INTEGER:
-            return @(sqlite3_column_int64(stmt, columnIdx)).stringValue;
+            return [NSString stringWithFormat:@"%lld", sqlite3_column_int64(stmt, columnIdx)];
         case SQLITE_FLOAT:
-            return  @(sqlite3_column_double(stmt, columnIdx)).stringValue;
+            return [NSString stringWithFormat:@"%f", sqlite3_column_double(stmt, columnIdx)];
         case SQLITE_BLOB:
             return [NSString stringWithFormat:@"Data (%@ bytes)",
                 @([self dataForColumnIndex:columnIdx stmt:stmt].length)
             ];
-            
+
         default:
             // Default to a string for everything else
             return [self stringForColumnIndex:columnIdx stmt:stmt] ?: NSNull.null;
     }
 }
-                
+
 - (NSString *)stringForColumnIndex:(int)columnIdx stmt:(sqlite3_stmt *)stmt {
     if (sqlite3_column_type(stmt, columnIdx) == SQLITE_NULL || columnIdx < 0) {
         return nil;
     }
-    
+
     const char *text = (const char *)sqlite3_column_text(stmt, columnIdx);
     return text ? @(text) : nil;
 }
@@ -303,10 +308,10 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
     if (sqlite3_column_type(stmt, columnIdx) == SQLITE_NULL || (columnIdx < 0)) {
         return nil;
     }
-    
+
     const void *blob = sqlite3_column_blob(stmt, columnIdx);
     NSInteger size = (NSInteger)sqlite3_column_bytes(stmt, columnIdx);
-    
+
     return blob ? [NSData dataWithBytes:blob length:size] : nil;
 }
 


### PR DESCRIPTION
Fix bug  #554: sqlite database viewer is broken

SQLite database viewer is broken on iOS. All table in database viewer are empty. The issue is this statement for column names isn't returning any rows. We don't know the reason yet. But even if we can get the column names from the current api, we will run the query for 3 times. With this change, we added a new API: queryTable. This API only needs to query the table once and get everything.