### PR TITLE
Do not use log_message.format on iOS 15 and above

### DIFF
--- a/Classes/ExplorerInterface/Tabs/FLEXTabList.m
+++ b/Classes/ExplorerInterface/Tabs/FLEXTabList.m
@@ -80,10 +80,10 @@
 
 - (void)closeTab:(UINavigationController *)tab {
     NSParameterAssert(tab);
-    NSParameterAssert([self.openTabs containsObject:tab]);
     NSInteger idx = [self.openTabs indexOfObject:tab];
-    
-    [self closeTabAtIndex:idx];
+    if (idx != NSNotFound) {
+        [self closeTabAtIndex:idx];
+    }
 }
 
 - (void)closeTabAtIndex:(NSInteger)idx {

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
@@ -169,9 +169,13 @@ static uint8_t (*OSLogGetType)(void *);
             
             // Get log message text
             const char *messageText = OSLogCopyFormattedMessage(log_message);
-            // https://github.com/limneos/oslog/issues/1
-            if (entry->log_message.format && !(strcmp(entry->log_message.format, messageText))) {
-                messageText = (char *)entry->log_message.format;
+            // https://github.com/FLEXTool/FLEX/issues/564
+            if (@available(iOS 15, *)) {
+            } else {
+              // https://github.com/limneos/oslog/issues/1
+              if (entry->log_message.format && !(strcmp(entry->log_message.format, messageText))) {
+                  messageText = (char *)entry->log_message.format;
+              }
             }
             // move messageText from stack to heap
             NSString *msg = [NSString stringWithUTF8String:messageText];


### PR DESCRIPTION
This mitigates #564, I have verified the log still works without this extra logic.

I still didn't find the root cause of #564, but there must be something changed on iOS 15.