### PR TITLE
Fix FLEXMacros header visibility in xcodeproj

### DIFF
--- a/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
@@ -170,7 +170,7 @@ static uint8_t (*OSLogGetType)(void *);
             // Get log message text
             const char *messageText = OSLogCopyFormattedMessage(log_message);
             // https://github.com/limneos/oslog/issues/1
-            if (entry->log_message.format && !(strcmp(entry->log_message.format, messageText))) {
+            if (!messageText || (entry->log_message.format && !(strcmp(entry->log_message.format, messageText)))) {
                 messageText = (char *)entry->log_message.format;
             }
             // move messageText from stack to heap

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.h
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.h
@@ -9,6 +9,8 @@
 
 #import "FLEXRuntimeConstants.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface FLEXIvar : NSObject
 
 + (instancetype)ivar:(Ivar)ivar;
@@ -31,17 +33,19 @@
 @property (nonatomic, readonly) NSString        *details;
 /// The full path of the image that contains this ivar definition,
 /// or \c nil if this ivar was probably defined at runtime.
-@property (nonatomic, readonly) NSString        *imagePath;
+@property (nonatomic, readonly, nullable) NSString *imagePath;
 
 /// For internal use
 @property (nonatomic) id tag;
 
-- (id)getValue:(id)target;
-- (void)setValue:(id)value onObject:(id)target;
+- (nullable id)getValue:(id)target;
+- (void)setValue:(nullable id)value onObject:(id)target;
 
 /// Calls into -getValue: and passes that value into
 /// -[FLEXRuntimeUtility potentiallyUnwrapBoxedPointer:type:]
 /// and returns the result
-- (id)getPotentiallyUnboxedValue:(id)target;
+- (nullable id)getPotentiallyUnboxedValue:(id)target;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXIvar.m
@@ -24,14 +24,6 @@
 
 #pragma mark Initializers
 
-- (id)init {
-    [NSException
-        raise:NSInternalInconsistencyException
-        format:@"Class instance should not be created with -init"
-    ];
-    return nil;
-}
-
 + (instancetype)ivar:(Ivar)ivar {
     return [[self alloc] initWithIvar:ivar];
 }

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXMirror.h
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXMirror.h
@@ -8,25 +8,17 @@
 //
 
 #import <Foundation/Foundation.h>
-@class FLEXMethod, FLEXProperty, FLEXIvar, FLEXProtocol;
 #import <objc/runtime.h>
+@class FLEXMethod, FLEXProperty, FLEXIvar, FLEXProtocol;
 
+NS_ASSUME_NONNULL_BEGIN
 
-#pragma mark FLEXMirror
-@interface FLEXMirror : NSObject
+#pragma mark FLEXMirror Protocol
+NS_SWIFT_NAME(FLEXMirrorProtocol)
+@protocol FLEXMirror <NSObject>
 
-/// Reflects an instance of an object or \c Class.
-/// @discussion \c FLEXMirror will immediately gather all useful information. Consider using the
-/// \c NSObject categories provided if your code will only use a few pieces of information,
-/// or if your code needs to run faster.
-///
-/// If you reflect an instance of a class then \c methods and \c properties will be populated
-/// with instance methods and properties. If you reflect a class itself, then \c methods
-/// and \c properties will be populated with class methods and properties as you'd expect.
-///
-/// @param objectOrClass An instance of an objct or a \c Class object.
-/// @return An instance of \c FLEXMirror.
-+ (instancetype)reflect:(id)objectOrClass;
+/// Swift initializer
+- (instancetype)initWithSubject:(id)objectOrClass NS_SWIFT_NAME(init(reflecting:));
 
 /// The underlying object or \c Class used to create this \c FLEXMirror instance.
 @property (nonatomic, readonly) id   value;
@@ -41,7 +33,36 @@
 @property (nonatomic, readonly) NSArray<FLEXProtocol *> *protocols;
 
 /// @return A reflection of \c value.superClass.
-@property (nonatomic, readonly) FLEXMirror *superMirror;
+@property (nonatomic, readonly, nullable) id<FLEXMirror> superMirror NS_SWIFT_NAME(superMirror);
+
+@end
+
+#pragma mark FLEXMirror Class
+@interface FLEXMirror : NSObject <FLEXMirror>
+
+/// Reflects an instance of an object or \c Class.
+/// @discussion \c FLEXMirror will immediately gather all useful information. Consider using the
+/// \c NSObject categories provided if your code will only use a few pieces of information,
+/// or if your code needs to run faster.
+///
+/// If you reflect an instance of a class then \c methods and \c properties will be populated
+/// with instance methods and properties. If you reflect a class itself, then \c methods
+/// and \c properties will be populated with class methods and properties as you'd expect.
+///
+/// @param objectOrClass An instance of an objct or a \c Class object.
+/// @return An instance of \c FLEXMirror.
++ (instancetype)reflect:(id)objectOrClass;
+
+@property (nonatomic, readonly) id   value;
+@property (nonatomic, readonly) BOOL isClass;
+@property (nonatomic, readonly) NSString *className;
+
+@property (nonatomic, readonly) NSArray<FLEXProperty *> *properties;
+@property (nonatomic, readonly) NSArray<FLEXIvar *>     *ivars;
+@property (nonatomic, readonly) NSArray<FLEXMethod *>   *methods;
+@property (nonatomic, readonly) NSArray<FLEXProtocol *> *protocols;
+
+@property (nonatomic, readonly, nullable) FLEXMirror *superMirror NS_SWIFT_NAME(superMirror);
 
 @end
 
@@ -49,12 +70,14 @@
 @interface FLEXMirror (ExtendedMirror)
 
 /// @return The method with the given name, or \c nil if one does not exist.
-- (FLEXMethod *)methodNamed:(NSString *)name;
+- (nullable FLEXMethod *)methodNamed:(nullable NSString *)name;
 /// @return The property with the given name, or \c nil if one does not exist.
-- (FLEXProperty *)propertyNamed:(NSString *)name;
+- (nullable FLEXProperty *)propertyNamed:(nullable NSString *)name;
 /// @return The instance variable with the given name, or \c nil if one does not exist.
-- (FLEXIvar *)ivarNamed:(NSString *)name;
+- (nullable FLEXIvar *)ivarNamed:(nullable NSString *)name;
 /// @return The protocol with the given name, or \c nil if one does not exist.
-- (FLEXProtocol *)protocolNamed:(NSString *)name;
+- (nullable FLEXProtocol *)protocolNamed:(nullable NSString *)name;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.h
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.h
@@ -10,6 +10,8 @@
 #import "FLEXRuntimeConstants.h"
 @class FLEXProperty, FLEXMethodDescription;
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark FLEXProtocol
 @interface FLEXProtocol : NSObject
 
@@ -23,22 +25,22 @@
 /// The name of the protocol.
 @property (nonatomic, readonly) NSString *name;
 /// The required methods of the protocol, if any. This includes property getters and setters.
-@property (nonatomic, readonly) NSArray<FLEXMethodDescription *>  *requiredMethods;
+@property (nonatomic, readonly) NSArray<FLEXMethodDescription *> *requiredMethods;
 /// The optional methods of the protocol, if any. This includes property getters and setters.
-@property (nonatomic, readonly) NSArray<FLEXMethodDescription *>  *optionalMethods;
+@property (nonatomic, readonly) NSArray<FLEXMethodDescription *> *optionalMethods;
 /// All protocols that this protocol conforms to, if any.
-@property (nonatomic, readonly) NSArray<FLEXProtocol *>  *protocols;
+@property (nonatomic, readonly) NSArray<FLEXProtocol *> *protocols;
 /// The full path of the image that contains this protocol definition,
 /// or \c nil if this protocol was probably defined at runtime.
-@property (nonatomic, readonly) NSString *imagePath;
+@property (nonatomic, readonly, nullable) NSString *imagePath;
 
 /// The properties in the protocol, if any. \c nil on iOS 10+ 
-@property (nonatomic, readonly) NSArray<FLEXProperty *>  *properties API_DEPRECATED("Use the more specific accessors below", ios(2.0, 10.0));
+@property (nonatomic, readonly, nullable) NSArray<FLEXProperty *> *properties API_DEPRECATED("Use the more specific accessors below", ios(2.0, 10.0));
 
 /// The required properties in the protocol, if any.
-@property (nonatomic, readonly) NSArray<FLEXProperty *>  *requiredProperties API_AVAILABLE(ios(10.0));
+@property (nonatomic, readonly) NSArray<FLEXProperty *> *requiredProperties API_AVAILABLE(ios(10.0));
 /// The optional properties in the protocol, if any.
-@property (nonatomic, readonly) NSArray<FLEXProperty *>  *optionalProperties API_AVAILABLE(ios(10.0));
+@property (nonatomic, readonly) NSArray<FLEXProperty *> *optionalProperties API_AVAILABLE(ios(10.0));
 
 /// For internal use
 @property (nonatomic) id tag;
@@ -67,3 +69,5 @@
 /// \c YES if this is an instance method, \c NO if it is a class method, or \c nil if unspecified
 @property (nonatomic, readonly) NSNumber *instance;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.m
@@ -15,14 +15,6 @@
 
 @implementation FLEXProtocol
 
-- (id)init {
-    [NSException
-        raise:NSInternalInconsistencyException
-        format:@"Class instance should not be created with -init"
-    ];
-    return nil;
-}
-
 #pragma mark Initializers
 
 + (NSArray *)allProtocols {

--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.m
@@ -160,6 +160,9 @@
             return [FLEXProperty property:objcproperties[i]];
         }];
         
+        _requiredProperties = @[];
+        _optionalProperties = @[];
+        
         free(objcproperties);
     }
 }

--- a/FLEX.xcodeproj/project.pbxproj
+++ b/FLEX.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 		C386D6EB24199E9600699085 /* FLEX-ObjectExploring.h in Headers */ = {isa = PBXBuildFile; fileRef = C386D6EA24199E9600699085 /* FLEX-ObjectExploring.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C386D6ED24199EC600699085 /* FLEX-Runtime.h in Headers */ = {isa = PBXBuildFile; fileRef = C386D6EC24199EC600699085 /* FLEX-Runtime.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C386D6F02419A33F00699085 /* FLEXRuntimeConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = C386D6EF2419A33F00699085 /* FLEXRuntimeConstants.m */; };
-		C386D6F2241A96AD00699085 /* FLEXMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C386D6F1241A96AD00699085 /* FLEXMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C386D6F2241A96AD00699085 /* FLEXMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C386D6F1241A96AD00699085 /* FLEXMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C386D6F3241A976100699085 /* FLEXRuntimeConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = C386D6EE2419A2F400699085 /* FLEXRuntimeConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C386D6F6241A9D6900699085 /* FLEX-Categories.h in Headers */ = {isa = PBXBuildFile; fileRef = C386D6F5241A9D6900699085 /* FLEX-Categories.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C3878DBA23A749960038FDBE /* FLEXVariableEditorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C3878DB823A749960038FDBE /* FLEXVariableEditorViewController.m */; };


### PR DESCRIPTION
Make the visibility of `FLEXMacros.h` (in the repo's Xcode project) match the visibility declared in `FLEX.podspec`.