### PR TITLE
Add fallback column query support when PRAGMA table_info is not working

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLResult.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLResult.m
@@ -13,7 +13,7 @@
 @synthesize keyedRows = _keyedRows;
 
 + (instancetype)message:(NSString *)message {
-    return [[self alloc] initWithmessage:message columns:nil rows:nil];
+    return [[self alloc] initWithMessage:message columns:nil rows:nil];
 }
 
 + (instancetype)error:(NSString *)message {
@@ -23,12 +23,12 @@
 }
 
 + (instancetype)columns:(NSArray<NSString *> *)columnNames rows:(NSArray<NSArray<NSString *> *> *)rowData {
-    return [[self alloc] initWithmessage:nil columns:columnNames rows:rowData];
+    return [[self alloc] initWithMessage:nil columns:columnNames rows:rowData];
 }
 
-- (id)initWithmessage:(NSString *)message columns:(NSArray *)columns rows:(NSArray<NSArray *> *)rows {
+- (instancetype)initWithMessage:(NSString *)message columns:(NSArray<NSString *> *)columns rows:(NSArray<NSArray<NSString *> *> *)rows {
     NSParameterAssert(message || (columns && rows));
-    NSParameterAssert(columns.count == rows.firstObject.count);
+    NSParameterAssert(rows.count == 0 || columns.count == rows.firstObject.count);
     
     self = [super init];
     if (self) {

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
@@ -158,7 +158,7 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
             return self.lastResult;
         }
         
-        // Grab columns
+        // Grab columns (columnCount will be 0 for insert/update/delete) 
         int columnCount = sqlite3_column_count(pstmt);
         NSArray<NSString *> *columns = [NSArray flex_forEachUpTo:columnCount map:^id(NSUInteger i) {
             return @(sqlite3_column_name(pstmt, (int)i));
@@ -176,8 +176,9 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
         }
         
         if (status == SQLITE_DONE) {
+            // columnCount will be 0 for insert/update/delete
             if (rows.count || columnCount > 0) {
-                // We selected some rows
+                // We executed a SELECT query
                 result = _lastResult = [FLEXSQLResult columns:columns rows:rows];
             } else {
                 // We executed a query like INSERT, UDPATE, or DELETE

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXSQLiteDatabaseManager.m
@@ -169,12 +169,12 @@ static NSString * const QUERY_TABLENAMES = @"SELECT name FROM sqlite_master WHER
         }
         
         if (status == SQLITE_DONE) {
-            int rowsAffected = sqlite3_changes(_db);
-            if (rows.count || !rowsAffected) {
+            if (rows.count || columnCount > 0) {
                 // We selected some rows
                 result = _lastResult = [FLEXSQLResult columns:columns rows:rows];
             } else {
                 // We executed a query like INSERT, UDPATE, or DELETE
+                int rowsAffected = sqlite3_changes(_db);
                 NSString *message = [NSString stringWithFormat:@"%d row(s) affected", rowsAffected];
                 result = _lastResult = [FLEXSQLResult message:message];
             }


### PR DESCRIPTION
Add fallback column query support when `PRAGMA table_info` is not working.

This is my attempt to fix #554, which is a less intrusive way comparing to #555. More detail about the bug itself can be found in #555.


The change I did here are two parts:
1. Fallback to use a slightly hackier solution when the `PRAGMA table_info` is not working.
2. Do not consider 0 row result as an `UPDATE/INSERT/DELETE`, it's common that our result has 0 rows.