### PR TITLE
Add option to copy row as CSV

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -154,12 +154,19 @@
         return [NSString stringWithFormat:@"%@:\n%@", self.columns[idx], field];
     }];
     
+    NSArray<NSString *> *values = [self.rows[row] flex_mapped:^id(NSString *value, NSUInteger idx) {
+        return [NSString stringWithFormat:@"'%@'", value];
+    }];
+    
     [FLEXAlert makeAlert:^(FLEXAlert *make) {
         make.title([@"Row " stringByAppendingString:@(row).stringValue]);
         NSString *message = [fields componentsJoinedByString:@"\n\n"];
         make.message(message);
         make.button(@"Copy").handler(^(NSArray<NSString *> *strings) {
             UIPasteboard.generalPasteboard.string = message;
+        });
+        make.button(@"Copy as CSV").handler(^(NSArray<NSString *> *strings) {
+            UIPasteboard.generalPasteboard.string = [values componentsJoinedByString:@", "];
         });
         
         // Option to delete row


### PR DESCRIPTION
Adding an option to copy a row in DB as comma separated values. This will make it easier to insert a row in DB using the feature implemented in #575 

https://user-images.githubusercontent.com/1477248/143222614-fd42d2e4-d4a5-4bb7-97ff-ca3c76c90edd.mov



