### PR TITLE
Mark some firebase related functions as static to avoid warnings

### DIFF
--- a/Classes/Network/FLEXFirebaseTransaction.mm
+++ b/Classes/Network/FLEXFirebaseTransaction.mm
@@ -28,7 +28,7 @@ typedef std::string (*ReturnsString)(void *);
 
 @end
 
-NSString * FLEXStringFromFIRRequestType(FLEXFIRRequestType type) {
+static NSString *FLEXStringFromFIRRequestType(FLEXFIRRequestType type) {
     switch (type) {
         case FLEXFIRRequestTypeNotFirebase:
             return @"not firebase";
@@ -49,7 +49,7 @@ NSString * FLEXStringFromFIRRequestType(FLEXFIRRequestType type) {
     return nil;
 }
 
-FLEXFIRTransactionDirection FIRDirectionFromRequestType(FLEXFIRRequestType type) {
+static FLEXFIRTransactionDirection FIRDirectionFromRequestType(FLEXFIRRequestType type) {
     switch (type) {
         case FLEXFIRRequestTypeNotFirebase:
             return FLEXFIRTransactionDirectionNone;
@@ -301,4 +301,3 @@ FLEXFIRTransactionDirection FIRDirectionFromRequestType(FLEXFIRRequestType type)
 //}
 
 @end
-

--- a/Classes/Network/FLEXNetworkTransaction.h
+++ b/Classes/Network/FLEXNetworkTransaction.h
@@ -132,8 +132,6 @@ typedef NS_ENUM(NSUInteger, FLEXFIRRequestType) {
     FLEXFIRRequestTypeDeleteDocument,
 };
 
-NSString * FLEXStringFromFIRRequestType(FLEXFIRRequestType type);
-
 @interface FLEXFirebaseSetDataInfo : NSObject
 /// The data that was set
 @property (nonatomic, readonly) NSDictionary *documentData;


### PR DESCRIPTION
Mark some firebase related functions as static to avoid warnings.
This function is not used externally, and shows warnings when compile. Let's fix it.

```
stderr: FLEX/src/Classes/Network/FLEXFirebaseTransaction.mm:52:29: error: no previous prototype for function 'FIRDirectionFromRequestType' [-Werror,-Wmissing-prototypes]
FLEXFIRTransactionDirection FIRDirectionFromRequestType(FLEXFIRRequestType type) {
                            ^
FLEX/src/Classes/Network/FLEXFirebaseTransaction.mm:52:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
FLEXFIRTransactionDirection FIRDirectionFromRequestType(FLEXFIRRequestType type) {
^
static
1 error generated.
```