### PR TITLE
Check rowIDs instead of rowIDs.count when validating input

### DIFF
--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXTableContentViewController.m
@@ -53,8 +53,8 @@
                       tableName:(nullable NSString *)tableName
                        database:(nullable id<FLEXDatabaseManager>)databaseManager {
     // Must supply all optional parameters as one, or none
-    BOOL all = rowIDs.count && tableName && databaseManager;
-    BOOL none = !rowIDs.count && !tableName && !databaseManager;
+    BOOL all = rowIDs && tableName && databaseManager;
+    BOOL none = !rowIDs && !tableName && !databaseManager;
     NSParameterAssert(all || none);
 
     self = [super init];


### PR DESCRIPTION
The row array could always be empty `@[]` for an empty db instead of `nil`. We shouldn't check `.count` which will cause crashes.