### PR TITLE
Fix unused-property-ivar warning for bytesReceived

### DIFF
--- a/Classes/Network/FLEXMITMDataSource.m
+++ b/Classes/Network/FLEXMITMDataSource.m
@@ -29,11 +29,11 @@
 }
 
 - (NSArray *)transactions {
-    return _filteredTransactions;
+    return self.isFiltered ? _filteredTransactions : _allTransactions;
 }
 
 - (NSInteger)bytesReceived {
-    return _filteredBytesReceived;
+    return self.isFiltered ? _filteredBytesReceived : _bytesReceived;
 }
 
 - (void)reloadByteCounts {


### PR DESCRIPTION
`bytesReceived` is defined as a property
```
@property (nonatomic) NSInteger bytesReceived;
```
If we turn on `-Wunused-property-ivar`, this warning will fire because the `_bytesReceived` is not used at all.
```
/FLEX/src/Classes/Network/FLEXMITMDataSource.m:35:1: error: ivar '_bytesReceived' which backs the property is not referenced in this property's accessor [-Werror,-Wunused-property-ivar]
- (NSInteger)bytesReceived {
^
/FLEX/src/Classes/Network/FLEXMITMDataSource.h:25:33: note: property declared here
@property (nonatomic) NSInteger bytesReceived;
                                ^
1 error generated.
```

I understand that `_filteredBytesReceived` is equivalent to `_bytesReceived` if not filtered, but it's not super intuitive. So let's just do an explicit check and make sure to use the ivar to shut up the warning.