### PR TITLE
Fix -Wobjc-signed-char-bool-implicit-int-conversion issue

### DIFF
--- a/Classes/Core/Controllers/FLEXNavigationController.m
+++ b/Classes/Core/Controllers/FLEXNavigationController.m
@@ -104,7 +104,7 @@
 }
 
 - (BOOL)canShowToolbar {
-    return self.topViewController.toolbarItems.count;
+    return self.topViewController.toolbarItems.count > 0;
 }
 
 - (void)addNavigationBarItemsToViewController:(UINavigationItem *)navigationItem {


### PR DESCRIPTION
It's an annoying warning and caused my local build to fail when treating warning as error. Let's just fix it.