### PR TITLE
Fix -Wobjc-signed-char-bool-implicit-int-conversion issue

### DIFF
--- a/Classes/Core/Controllers/FLEXTableViewController.m
+++ b/Classes/Core/Controllers/FLEXTableViewController.m
@@ -66,9 +66,10 @@ CGFloat const kFLEXDebounceForExpensiveIO = 0.5;
         _searchBarDebounceInterval = kFLEXDebounceFast;
         _showSearchBarInitially = YES;
         _style = style;
-        _manuallyDeactivateSearchOnDisappear = ({
-            NSProcessInfo.processInfo.operatingSystemVersion.majorVersion < 11;
-        });
+        _manuallyDeactivateSearchOnDisappear = YES;
+        if (@available(iOS 11.0, *)) {
+            _manuallyDeactivateSearchOnDisappear = NO;
+        }
         
         // We will be our own search delegate if we implement this method
         if ([self respondsToSelector:@selector(updateSearchResults:)]) {


### PR DESCRIPTION
It's an annoying warning and caused my local build to fail when treating warning as error. Let's just fix it.
Error:
```
stderr: FLEX/src/Classes/Core/Controllers/FLEXTableViewController.m:69:46: error: implicit conversion from integral type 'int' to 'BOOL' [-Werror,-Wobjc-signed-char-bool-implicit-int-conversion]
[CONTEXT]         _manuallyDeactivateSearchOnDisappear = ({
[CONTEXT]                                              ^
```