### PR TITLE
Add accessibilityIdentifier and accessibilityLabel to views properties

### DIFF
--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXShortcutsFactory+Defaults.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXShortcutsFactory+Defaults.m
@@ -77,7 +77,8 @@
         @"frame", @"bounds", @"center", @"transform",
         @"backgroundColor", @"alpha", @"opaque", @"hidden",
         @"clipsToBounds", @"userInteractionEnabled", @"layer",
-        @"superview", @"subviews"
+        @"superview", @"subviews",
+        @"accessibilityIdentifier", @"accessibilityLabel"
     ]).forClass(UIView.class);
 
     // UILabel
@@ -86,7 +87,8 @@
         @"textColor", @"textAlignment", @"numberOfLines",
         @"lineBreakMode", @"enabled", @"backgroundColor",
         @"alpha", @"hidden", @"preferredMaxLayoutWidth",
-        @"superview", @"subviews"
+        @"superview", @"subviews",
+        @"accessibilityIdentifier", @"accessibilityLabel"
     ]).forClass(UILabel.class);
 
     // UIWindow
@@ -111,14 +113,16 @@
     self.append.ivars(ivars).methods(methods).properties(@[
         @"enabled", @"allTargets", @"frame",
         @"backgroundColor", @"hidden", @"clipsToBounds",
-        @"userInteractionEnabled", @"superview", @"subviews"
+        @"userInteractionEnabled", @"superview", @"subviews",
+        @"accessibilityIdentifier", @"accessibilityLabel"
     ]).forClass(UIControl.class);
 
     // UIButton
     self.append.ivars(ivars).properties(@[
         @"titleLabel", @"font", @"imageView", @"tintColor",
         @"currentTitle", @"currentImage", @"enabled", @"frame",
-        @"superview", @"subviews"
+        @"superview", @"subviews",
+        @"accessibilityIdentifier", @"accessibilityLabel"
     ]).forClass(UIButton.class);
     
     // UIImageView
@@ -126,6 +130,7 @@
         @"image", @"animationImages", @"frame", @"bounds", @"center",
         @"transform", @"alpha", @"hidden", @"clipsToBounds",
         @"userInteractionEnabled", @"layer", @"superview", @"subviews",
+        @"accessibilityIdentifier", @"accessibilityLabel"
     ]).forClass(UIImageView.class);
 }
 

--- a/Example/FLEXample/App/CommitListViewController.m
+++ b/Example/FLEXample/App/CommitListViewController.m
@@ -33,6 +33,7 @@
     self.navigationItem.rightBarButtonItem = [UIBarButtonItem
         flex_itemWithTitle:@"FLEX" target:FLEXManager.sharedManager action:@selector(toggleExplorer)
     ];
+    self.navigationItem.rightBarButtonItem.accessibilityIdentifier = @"toggle-explorer";
     
     // Load and process commits
     NSString *commitsURL = @"https://api.github.com/repos/Flipboard/FLEX/commits";


### PR DESCRIPTION
Can see accessibilityIdentifier and accessibilityLabel in view Shortcuts section. 
Useful for Accessibility debugging and finding UI in code.

![Screen Shot 2022-03-21 at 10 00 45 PM](https://user-images.githubusercontent.com/3101066/159413144-4e35b3f7-ca3d-4f5d-9659-2172fb27dbf4.png)
