### PR TITLE
Fix nil FLEXHTTPTransaction in recordRequestWillBeSentWithRequestID

### DIFF
--- a/Classes/Network/FLEXNetworkRecorder.m
+++ b/Classes/Network/FLEXNetworkRecorder.m
@@ -177,8 +177,6 @@ NSString *const kFLEXNetworkRecorderResponseCacheLimitDefaultsKey = @"com.flex.r
             return;
         }
     }
-    
-    FLEXHTTPTransaction *transaction = [FLEXHTTPTransaction request:request identifier:requestID];
 
     // Before async block to keep times accurate
     if (redirectResponse) {
@@ -187,6 +185,11 @@ NSString *const kFLEXNetworkRecorderResponseCacheLimitDefaultsKey = @"com.flex.r
     }
 
     dispatch_async(self.queue, ^{
+        FLEXHTTPTransaction *transaction = [FLEXHTTPTransaction request:request identifier:requestID];
+        if (!transaction) {
+            return;
+        }
+
         [self.orderedHTTPTransactions insertObject:transaction atIndex:0];
         self.requestIDsToTransactions[requestID] = transaction;
 

--- a/Classes/Network/FLEXNetworkRecorder.m
+++ b/Classes/Network/FLEXNetworkRecorder.m
@@ -145,7 +145,7 @@ NSString *const kFLEXNetworkRecorderResponseCacheLimitDefaultsKey = @"com.flex.r
         }
 
         [self notify:kFLEXNetworkRecorderTransactionsClearedNotification transaction:nil];
-    }
+    });
 }
 
 - (void)clearExcludedTransactions {


### PR DESCRIPTION
The transaction could be `nil`, we have checks in other callbacks like `recordResponseReceivedWithRequestID` and `recordDataReceivedWithRequestID`. So we should have it here as well to avoid crash.

This should fix #574 as the stack trace is the same.