### PR TITLE
Fix self.allTransactions race condition in FLEXMITMDataSource

### DIFF
--- a/Classes/Network/FLEXMITMDataSource.m
+++ b/Classes/Network/FLEXMITMDataSource.m
@@ -53,8 +53,9 @@
         self.filteredTransactions = self.allTransactions;
         if (completion) completion(self);
     } else {
+        NSArray<FLEXNetworkTransaction *> *allTransactions = self.allTransactions.copy;
         [self onBackgroundQueue:^NSArray *{
-            return [self.allTransactions flex_filtered:^BOOL(FLEXNetworkTransaction *entry, NSUInteger idx) {
+            return [allTransactions flex_filtered:^BOOL(FLEXNetworkTransaction *entry, NSUInteger idx) {
                 return [entry matchesQuery:searchString];
             }];
         } thenOnMainQueue:^(NSArray *filteredNetworkTransactions) {


### PR DESCRIPTION
There is a crash caused by this because of race condition. Here we can simply make a copy of the transaction and it will be used and released properly even within the block.

The crash is both reported in #574 as well as my internal crash log:
```
Thread #32 Crashed:
0 libobjc.A.dylib 0x198de1540 objc_msgSend + 0x20
1 FLEXFramework 0x110104c00 __40-[FLEXMITMDataSource filter:completion:]_block_invoke (FLEXMITMDataSource.m:57)
2 FLEXFramework 0x110105110 __56-[FLEXMITMDataSource onBackgroundQueue:thenOnMainQueue:]_block_invoke (FLEXMITMDataSource.m:99)
3 libdispatch.dylib 0x180215920 _dispatch_call_block_and_release + 0x1c
4 libdispatch.dylib 0x18021766c _dispatch_client_callout + 0x10
5 libdispatch.dylib 0x18021a794 _dispatch_queue_override_invoke + 0x314
6 libdispatch.dylib 0x180228ddc _dispatch_root_queue_drain + 0x188
7 libdispatch.dylib 0x180229604 _dispatch_worker_thread2 + 0xa0
8 libsystem_pthread.dylib 0x1f191f0b4 _pthread_wqthread + 0xe0
```