### PR TITLE
[System Log] Always show SearchBar & Alway filter new log if filterText is not empty

### DIFF
--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
@@ -98,7 +98,7 @@ static BOOL my_os_log_shim_enabled(void *addr) {
     [super viewDidLoad];
 
     self.showsSearchBar = YES;
-    self.showSearchBarInitially = NO;
+    self.pinSearchBar = YES;
 
     weakify(self)
     id logHandler = ^(NSArray<FLEXSystemLogMessage *> *newMessages) { strongify(self)

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
@@ -182,7 +182,8 @@ static BOOL my_os_log_shim_enabled(void *addr) {
     }
 
     // "Follow" the log as new messages stream in if we were previously near the bottom.
-    BOOL wasNearBottom = self.tableView.contentOffset.y >= self.tableView.contentSize.height - self.tableView.frame.size.height - 100.0;
+    UITableView *tv = self.tableView;
+    BOOL wasNearBottom = tv.contentOffset.y >= tv.contentSize.height - tv.frame.size.height - 100.0;
     [self reloadData];
     if (wasNearBottom) {
         [self scrollToLastRow];
@@ -192,8 +193,8 @@ static BOOL my_os_log_shim_enabled(void *addr) {
 - (void)scrollToLastRow {
     NSInteger numberOfRows = [self.tableView numberOfRowsInSection:0];
     if (numberOfRows > 0) {
-        NSIndexPath *lastIndexPath = [NSIndexPath indexPathForRow:numberOfRows - 1 inSection:0];
-        [self.tableView scrollToRowAtIndexPath:lastIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];
+        NSIndexPath *last = [NSIndexPath indexPathForRow:numberOfRows - 1 inSection:0];
+        [self.tableView scrollToRowAtIndexPath:last atScrollPosition:UITableViewScrollPositionBottom animated:YES];
     }
 }
 

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogViewController.m
@@ -175,6 +175,11 @@ static BOOL my_os_log_shim_enabled(void *addr) {
     [self.logMessages mutate:^(NSMutableArray *list) {
         [list addObjectsFromArray:newMessages];
     }];
+    
+    // Re-filter messages to filter against new messages
+    if (self.filterText.length) {
+        [self updateSearchResults:self.filterText];
+    }
 
     // "Follow" the log as new messages stream in if we were previously near the bottom.
     BOOL wasNearBottom = self.tableView.contentOffset.y >= self.tableView.contentSize.height - self.tableView.frame.size.height - 100.0;


### PR DESCRIPTION
I encountered 2 problems in the process of using Flex System Log
1. After entering the System Log page, it's need to scroll to top and show the SearchBar. I think it would be better to keep it pinned.
2. handleUpdateWithNewMessages, a function that accepts new messages, is called a lot, but the messages are not filtered in this function, and course some problem. For example, activate the SearchBar and enter the filter text, then click the search button on keyboard, and then the keyboard exits. Received new message, but after call ```[self reloadData]```, all messages are unfiltered.


> video
https://user-images.githubusercontent.com/2723525/162410523-ea8b10af-6e9d-43d9-bab9-c8c2bbb4d5c8.mp4
