### PR TITLE
Fix implicit casting warnings

### DIFF
--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputTextView.m
@@ -128,7 +128,7 @@
 }
 
 - (CGFloat)inputTextViewHeight {
-    return ceil([[self class] inputFont].lineHeight * self.numberOfInputLines) + 16.0;
+    return ceil([[self class] inputFont].lineHeight * (CGFloat)self.numberOfInputLines) + 16.0;
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {

--- a/Classes/ExplorerInterface/FLEXWindowManagerController.m
+++ b/Classes/ExplorerInterface/FLEXWindowManagerController.m
@@ -245,10 +245,6 @@
                 } showFrom:self];
             }
     }
-
-    __block UIWindow *targetWindow = nil, *oldKeyWindow = nil;
-    __block UIWindowLevel oldLevel;
-    __block BOOL wasVisible;
     
     subtitle = [subtitle stringByAppendingString:
         @"\n\n1) Adjust the FLEX window level relative to this window,\n"
@@ -260,26 +256,29 @@
     [FLEXAlert makeAlert:^(FLEXAlert *make) {
         make.title(NSStringFromClass(window.class)).message(subtitle);
         make.button(@"Adjust FLEX Window Level").handler(^(NSArray<NSString *> *strings) {
-            targetWindow = flex; oldLevel = flex.windowLevel;
-            flex.windowLevel = window.windowLevel + strings.firstObject.integerValue;
+            UIWindow *const targetWindow = flex;
+            const UIWindowLevel oldLevel = flex.windowLevel;
+            flex.windowLevel = window.windowLevel + (UIWindowLevel)strings.firstObject.integerValue;
             
             [self showRevertOrDismissAlert:^{ targetWindow.windowLevel = oldLevel; }];
         });
         make.button(@"Adjust This Window's Level").handler(^(NSArray<NSString *> *strings) {
-            targetWindow = window; oldLevel = window.windowLevel;
-            window.windowLevel = flex.windowLevel + strings.firstObject.integerValue;
+            UIWindow *const targetWindow = window;
+            const UIWindowLevel oldLevel = window.windowLevel;
+            window.windowLevel = flex.windowLevel + (UIWindowLevel)strings.firstObject.integerValue;
             
             [self showRevertOrDismissAlert:^{ targetWindow.windowLevel = oldLevel; }];
         });
         make.button(@"Set This Window's Level").handler(^(NSArray<NSString *> *strings) {
-            targetWindow = window; oldLevel = window.windowLevel;
-            window.windowLevel = strings.firstObject.integerValue;
+            UIWindow *const targetWindow = window;
+            const UIWindowLevel oldLevel = window.windowLevel;
+            window.windowLevel = (UIWindowLevel)strings.firstObject.integerValue;
             
             [self showRevertOrDismissAlert:^{ targetWindow.windowLevel = oldLevel; }];
         });
         make.button(@"Make Key And Visible").handler(^(NSArray<NSString *> *strings) {
-            oldKeyWindow = UIApplication.sharedApplication.keyWindow;
-            wasVisible = window.hidden;
+            UIWindow *_Nullable const oldKeyWindow = UIApplication.sharedApplication.keyWindow;
+            const BOOL wasVisible = window.hidden;
             [window makeKeyAndVisible];
             
             [self showRevertOrDismissAlert:^{

--- a/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
+++ b/Classes/GlobalStateExplorers/DatabaseBrowser/FLEXMultiColumnTableView.m
@@ -91,7 +91,7 @@ static const CGFloat kColumnMargin = 1;
         self.contentTableView.frame.size.width, self.headerScrollView.frame.size.height
     );
     self.contentTableView.frame = CGRectMake(
-        0, 0, contentWidth + self.numberOfColumns * self.columnMargin , contentHeight
+        0, 0, contentWidth + (CGFloat)self.numberOfColumns * self.columnMargin , contentHeight
     );
     self.contentScrollView.frame = CGRectMake(
         leftHeaderWidth, topheaderHeight + topInsets, width - leftHeaderWidth, contentHeight

--- a/Classes/GlobalStateExplorers/RuntimeBrowser/FLEXKeyboardToolbar.m
+++ b/Classes/GlobalStateExplorers/RuntimeBrowser/FLEXKeyboardToolbar.m
@@ -9,9 +9,9 @@
 #import "FLEXKeyboardToolbar.h"
 #import "FLEXUtility.h"
 
-#define kToolbarHeight 44
-#define kButtonSpacing 6
-#define kScrollViewHorizontalMargins 3
+const CGFloat kToolbarHeight = 44.0f;
+const CGFloat kButtonSpacing = 6.0f;
+const CGFloat kScrollViewHorizontalMargins = 3.0f;
 
 @interface FLEXKeyboardToolbar ()
 
@@ -158,7 +158,7 @@
 }
 
 - (void)addButtons {
-    NSUInteger originX = 0.f;
+    CGFloat originX = 0.f;
     
     CGRect originFrame;
     CGFloat top    = self.scrollView.contentInset.top;

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXOSLogController.m
@@ -165,7 +165,7 @@ static uint8_t (*OSLogGetType)(void *);
             os_log_message_t log_message = &entry->log_message;
             
             // Get date
-            NSDate *date = [NSDate dateWithTimeIntervalSince1970:log_message->tv_gmt.tv_sec];
+            NSDate *date = [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval)log_message->tv_gmt.tv_sec];
             
             // Get log message text
             // https://github.com/limneos/oslog/issues/1

--- a/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogMessage.m
+++ b/Classes/GlobalStateExplorers/SystemLog/FLEXSystemLogMessage.m
@@ -17,7 +17,7 @@
 
     const char *timestamp = asl_get(aslMessage, ASL_KEY_TIME);
     if (timestamp) {
-        NSTimeInterval timeInterval = [@(timestamp) integerValue];
+        NSTimeInterval timeInterval = (NSTimeInterval)[@(timestamp) integerValue];
         const char *nanoseconds = asl_get(aslMessage, ASL_KEY_TIME_NSEC);
         if (nanoseconds) {
             timeInterval += [@(nanoseconds) doubleValue] / NSEC_PER_SEC;

--- a/Classes/Network/FLEXNetworkSettingsController.m
+++ b/Classes/Network/FLEXNetworkSettingsController.m
@@ -65,8 +65,8 @@
     ];
     
     UISlider *slider = self.cacheLimitSlider;
-    self.cacheLimitValue = FLEXNetworkRecorder.defaultRecorder.responseCacheByteLimit;
-    const NSUInteger fiftyMega = 50 * 1024 * 1024;
+    self.cacheLimitValue = (float)FLEXNetworkRecorder.defaultRecorder.responseCacheByteLimit;
+    const float fiftyMega = 50.0 * 1024 * 1024;
     slider.minimumValue = 0;
     slider.maximumValue = fiftyMega;
     slider.value = self.cacheLimitValue;

--- a/Classes/Toolbar/FLEXExplorerToolbar.m
+++ b/Classes/Toolbar/FLEXExplorerToolbar.m
@@ -104,7 +104,7 @@
     CGFloat originX = CGRectGetMaxX(self.dragHandle.frame);
     CGFloat originY = CGRectGetMinY(safeArea);
     CGFloat height = kToolbarItemHeight;
-    CGFloat width = FLEXFloor((CGRectGetWidth(safeArea) - CGRectGetWidth(self.dragHandle.frame)) / self.toolbarItems.count);
+    CGFloat width = FLEXFloor((CGRectGetWidth(safeArea) - CGRectGetWidth(self.dragHandle.frame)) / (CGFloat)self.toolbarItems.count);
     for (FLEXExplorerToolbarItem *toolbarItem in self.toolbarItems) {
         toolbarItem.currentItem.frame = CGRectMake(originX, originY, width, height);
         originX = CGRectGetMaxX(toolbarItem.currentItem.frame);

--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -390,7 +390,7 @@ BOOL FLEXConstructorsShouldRun() {
         stream.total_out = 0;
         stream.avail_out = 0;
 
-        NSMutableData *mutableData = [NSMutableData dataWithLength:compressedDataLength * 1.5];
+        NSMutableData *mutableData = [NSMutableData dataWithLength:(NSUInteger)(compressedDataLength * 1.5)];
         if (inflateInit2(&stream, 15 + 32) == Z_OK) {
             int status = Z_OK;
             while (status == Z_OK) {

--- a/Classes/Utility/Keyboard/FLEXKeyboardShortcutManager.m
+++ b/Classes/Utility/Keyboard/FLEXKeyboardShortcutManager.m
@@ -167,7 +167,7 @@
                 if (pressureLevel > 0) {
                     if (@available(iOS 9.0, *)) {
                         for (UITouch *touch in [event allTouches]) {
-                            double adjustedPressureLevel = pressureLevel * 20 * touch.maximumPossibleForce;
+                            double adjustedPressureLevel = (double)(pressureLevel * 20 * touch.maximumPossibleForce);
                             [touch setValue:@(adjustedPressureLevel) forKey:@"_pressure"];
                         }
                     }

--- a/Classes/ViewHierarchy/SnapshotExplorer/FHSSnapshotView.m
+++ b/Classes/ViewHierarchy/SnapshotExplorer/FHSSnapshotView.m
@@ -178,8 +178,8 @@
     _maxDepth = maxDepth;
 
     self.depthSlider.allowedMinValue = 0;
-    self.depthSlider.allowedMaxValue = maxDepth;
-    self.depthSlider.maxValue = maxDepth;
+    self.depthSlider.allowedMaxValue = (CGFloat)maxDepth;
+    self.depthSlider.maxValue = (CGFloat)maxDepth;
     self.depthSlider.minValue = 0;
 }
 
@@ -296,7 +296,7 @@
 - (void)depthSliderDidChange:(FHSRangeSlider *)slider {
     CGFloat min = slider.minValue, max = slider.maxValue;
     for (FHSSnapshotNodes *nodes in self.nodesMap.allValues) {
-        CGFloat depth = nodes.depth;
+        CGFloat depth = (CGFloat)nodes.depth;
         nodes.snapshot.hidden = depth < min || max < depth;
     }
 }

--- a/Classes/ViewHierarchy/SnapshotExplorer/Scene/SceneKit+Snapshot.m
+++ b/Classes/ViewHierarchy/SnapshotExplorer/Scene/SceneKit+Snapshot.m
@@ -184,7 +184,7 @@ CGFloat const kHeaderVerticalInset = 8.0;
         } else {
             positionRelativeToRoot = positionRelativeToParent;
         }
-        positionRelativeToRoot.z = 50 * depth;
+        positionRelativeToRoot.z = 50.0 * (float)depth;
         positionRelativeToRoot;
     });
 

--- a/Classes/ViewHierarchy/TreeExplorer/FLEXHierarchyTableViewCell.m
+++ b/Classes/ViewHierarchy/TreeExplorer/FLEXHierarchyTableViewCell.m
@@ -101,7 +101,7 @@
     maxWidth -= (hideCheckerView ? kContentPadding : (kViewColorIndicatorSize + kContentPadding * 2));
     
     CGRect depthIndicatorFrame = self.depthIndicatorView.frame = CGRectMake(
-        kContentPadding, 0, self.viewDepth * kDepthIndicatorWidthMultiplier, CGRectGetHeight(bounds)
+        kContentPadding, 0, (CGFloat)self.viewDepth * kDepthIndicatorWidthMultiplier, CGRectGetHeight(bounds)
     );
     
     // Circle goes after depth, and its center Y = textLabel's center Y


### PR DESCRIPTION
These are found by `-Wconversion`

- Use explicit cast to avoid implicit cast warnings
- Move params to local variable in blocks instead of using __block variables.