### PR TITLE
Fix -Wobjc-signed-char-bool-implicit-int-conversion for FLEXSwiftInternal

### DIFF
--- a/Classes/Utility/Runtime/Objc/FLEXSwiftInternal.mm
+++ b/Classes/Utility/Runtime/Objc/FLEXSwiftInternal.mm
@@ -85,8 +85,8 @@ extern "C" BOOL FLEXIsSwiftObjectOrClass(id objOrClass) {
     class_data_bits_t rodata = ((__bridge objc_class_ *)(cls))->bits;
     
     if (@available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *)) {
-        return rodata & FAST_IS_SWIFT_STABLE != 0;
+        return (rodata & FAST_IS_SWIFT_STABLE) != 0;
     } else {
-        return rodata & FAST_IS_SWIFT_LEGACY != 0;
+        return (rodata & FAST_IS_SWIFT_LEGACY) != 0;
     }
 }

--- a/Classes/Utility/Runtime/Objc/FLEXSwiftInternal.mm
+++ b/Classes/Utility/Runtime/Objc/FLEXSwiftInternal.mm
@@ -85,8 +85,8 @@ extern "C" BOOL FLEXIsSwiftObjectOrClass(id objOrClass) {
     class_data_bits_t rodata = ((__bridge objc_class_ *)(cls))->bits;
     
     if (@available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *)) {
-        return rodata & FAST_IS_SWIFT_STABLE;
+        return rodata & FAST_IS_SWIFT_STABLE != 0;
     } else {
-        return rodata & FAST_IS_SWIFT_LEGACY;
+        return rodata & FAST_IS_SWIFT_LEGACY != 0;
     }
 }


### PR DESCRIPTION
Fix `-Wobjc-signed-char-bool-implicit-int-conversion` for `FLEXSwiftInternal`

Fixing this trace. If you have the `-Wobjc-signed-char-bool-implicit-int-conversion` enabled and `-Werror` enabled this will fail to build.
```
[CONTEXT] 
stderr: FLEX/Classes/Utility/Runtime/Objc/FLEXSwiftInternal.mm:88:9: error: implicit conversion from integral type 'unsigned long' to 'BOOL' [-Werror,-Wobjc-signed-char-bool-implicit-int-conversion]
[CONTEXT]         return rodata & FAST_IS_SWIFT_STABLE;
[CONTEXT]         ^
[CONTEXT]                (                            ) ? YES : NO
```

See more context here: https://stackoverflow.com/questions/65302104/how-to-enable-the-compiler-option-wobjc-signed-char-bool-implicit-int-conversio