### PR TITLE
Fixed issue where websocket hook did not call original completion

### DIFF
--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -1591,15 +1591,19 @@ static FIRDocumentReference * _logos_method$_ungrouped$FIRCollectionReference$ad
         [FLEXNetworkObserver.sharedObserver
             websocketTask:slf sendMessagage:message
         ];
-        completion = ^(NSError *error) {
+        
+        id completionHook = ^(NSError *error) {
             [FLEXNetworkObserver.sharedObserver
                 websocketTaskMessageSendCompletion:message
                 error:error
             ];
+            if (completion) {
+                completion(error);
+            }
         };
         
         ((void(*)(id, SEL, id, id))objc_msgSend)(
-            slf, swizzledSelector, message, completion
+            slf, swizzledSelector, message, completionHook
         );
     };
 

--- a/Example/FLEXample/MiscNetworkRequests.m
+++ b/Example/FLEXample/MiscNetworkRequests.m
@@ -153,7 +153,7 @@
 }
 
 - (void)sendExampleWebsocketTraffic:(NSURLSession *)sessionWithDelegate {
-    NSString *APIKey = @"oCdCMcMPQpbvNjUIzqtvF1d2X2okWpDQj4AwARJuAgtjhzKxVEjQU6IdCjwm";
+    NSString *APIKey = @"VCXCEuvhGcBDP7XhiJJUDvR1e1D3eiVjgZ9VRiaV";
     NSString *wsurl = [NSString stringWithFormat:@"wss://demo.piesocket.com/v3/channel_1?api_key=%@&notify_self", APIKey];
     NSURLSessionWebSocketTask *task = [sessionWithDelegate webSocketTaskWithURL:[NSURL URLWithString:wsurl]];
     [task resume];
@@ -167,6 +167,8 @@
             [task sendMessage:message completionHandler:^(NSError *error) {
                 if (error) {
                     NSLog(@"Error sending WS message: %@", error.localizedDescription);
+                } else {
+                    NSLog(@"WS message sent.");
                 }
             }];
         }


### PR DESCRIPTION
Send message hook was changing original completion instead of wrapping it in a hook.
Similar hook already exists for receivemessage functionality, but it was not working for send-message, original completion was never called.
Adjusted code to create a new completionHook which records the information and then original completion block.

I also updated API-Key for piesocket and added a message after sending message, to make sure that completion is being called and at least success/failure message is logged.