### PR TITLE
Xcode 14 - Warnings related to iOS 11 support (Swift Package Manager)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ enum FLEXBuildOptions {
 
 #if swift(>=5.7)
 let platforms: [PackageDescription.SupportedPlatform] = [.iOS(.v11)]
-#elseif swift(>=5.0)
+#else
 let platforms: [PackageDescription.SupportedPlatform] = [.iOS(.v10)]
 #endif
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,15 @@ enum FLEXBuildOptions {
     static let silenceWarnings = false
 }
 
+#if swift(>=5.7)
+let platforms: [PackageDescription.SupportedPlatform] = [.iOS(.v11)]
+#elseif swift(>=5.0)
+let platforms: [PackageDescription.SupportedPlatform] = [.iOS(.v10)]
+#endif
+
 let package = Package(
     name: "FLEX",
-    platforms: [.iOS(.v10)],
+    platforms: platforms,
     products: [
         .library(name: "FLEX", targets: ["FLEX"])
     ],


### PR DESCRIPTION
Hi,
I would like to contribute fixing a recent warning.

The new Xcode 14 uses iOS SDK 11.0 as base, and compiling in this Xcode shows a warning.
Handle this restriction relying on swift version.

Regards and comments welcomed