### PR TITLE
Use queue instead of self.queue in FLEXNetworkRecorder.m

### DIFF
--- a/Classes/Network/FLEXNetworkRecorder.m
+++ b/Classes/Network/FLEXNetworkRecorder.m
@@ -16,7 +16,7 @@
 
 #define Synchronized(queue, obj) ({ \
     __block id __synchronized_retval = nil; \
-    dispatch_sync(self.queue, ^{ __synchronized_retval = obj; }); \
+    dispatch_sync(queue, ^{ __synchronized_retval = obj; }); \
     __synchronized_retval; \
 })
     


### PR DESCRIPTION
Small bug introduced in https://github.com/FLEXTool/FLEX/commit/b45c655ba2432f827d6b07faf9844a9111c51716