### PR TITLE
Allow unloading of FLEX window and view controller

### DIFF
--- a/Classes/Manager/FLEXManager.h
+++ b/Classes/Manager/FLEXManager.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showExplorer;
 - (void)hideExplorer;
 - (void)toggleExplorer;
+- (void)unloadExplorer;
 
 /// Programmatically dismiss anything presented by FLEX, leaving only the toolbar visible.
 - (void)dismissAnyPresentedTools:(void (^_Nullable)(void))completion;

--- a/Classes/Manager/FLEXManager.m
+++ b/Classes/Manager/FLEXManager.m
@@ -82,6 +82,13 @@
     self.explorerWindow.hidden = YES;
 }
 
+- (void)unloadExplorer {
+    [self.userGlobalEntries removeAllObjects];
+    [self.customContentTypeViewers removeAllObjects];
+    self.explorerViewController = nil;
+    self.explorerWindow = nil;
+}
+
 - (void)toggleExplorer {
     if (self.explorerWindow.isHidden) {
         if (@available(iOS 13.0, *)) {


### PR DESCRIPTION
FLEX manager singleton stays, once created.  Use `[[FLEXManager sharedManager] unloadExplorer];` to hide and unload FLEX view controller and window.

Unloading these items unhooks all swizzled methods.  They'll be recreated next time `[[FLEXManager sharedManager] showExplorer];` is called.