### PR TITLE
Fix missing linked file in Headers directory

### DIFF
--- a/Classes/Headers/NSDateFormatter+FLEX.h
+++ b/Classes/Headers/NSDateFormatter+FLEX.h
@@ -1,0 +1,1 @@
+/Users/bandarhelal/Documents/GitHub/FLEX/Classes/Utility/Categories/NSDateFormatter+FLEX.h


### PR DESCRIPTION
When you install FLEX from Swift Package Manager you get this error, because ```NSDateFormatter+FLEX.h``` it's missing from Headers directory
<img width="269" alt="Screen Shot 2022-08-31 at 6 27 37 PM" src="https://user-images.githubusercontent.com/31299470/187717988-0bb0bad2-c5ba-4573-b1c5-3c64d6f3b03e.png">
