### PR TITLE
ObjectExplorer: Add a new Shortcut for UIWindow to change animations speed

### DIFF
--- a/Classes/ObjectExplorers/FLEXObjectExplorerFactory.m
+++ b/Classes/ObjectExplorers/FLEXObjectExplorerFactory.m
@@ -10,6 +10,7 @@
 #import "FLEXGlobalsViewController.h"
 #import "FLEXClassShortcuts.h"
 #import "FLEXViewShortcuts.h"
+#import "FLEXWindowShortcuts.h"
 #import "FLEXViewControllerShortcuts.h"
 #import "FLEXUIAppShortcuts.h"
 #import "FLEXImageShortcuts.h"
@@ -48,6 +49,7 @@ static NSMutableDictionary<id<NSCopying>, Class> *classesToRegisteredSections = 
             ClassKey(UIViewController) : [FLEXViewControllerShortcuts class],
             ClassKey(UIApplication)    : [FLEXUIAppShortcuts class],
             ClassKey(UIView)           : [FLEXViewShortcuts class],
+            ClassKey(UIWindow)         : [FLEXWindowShortcuts class],
             ClassKey(UIImage)          : [FLEXImageShortcuts class],
             ClassKey(CALayer)          : [FLEXLayerShortcuts class],
             ClassKey(UIColor)          : [FLEXColorPreviewSection class],

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
@@ -11,6 +11,7 @@
 #import "FLEXRuntimeUtility.h"
 #import "FLEXObjectExplorerFactory.h"
 #import "FLEXImagePreviewViewController.h"
+#import "FLEXAlert.h"
 
 @interface FLEXViewShortcuts ()
 @property (nonatomic, readonly) UIView *view;
@@ -61,7 +62,7 @@
     // and go forward again and it will show if the view controller is nil or changed.
     UIViewController *controller = [FLEXViewShortcuts nearestViewControllerForView:view];
 
-    return [self forObject:view additionalRows:@[
+    NSMutableArray *rows = @[
         [FLEXActionShortcut title:@"Nearest View Controller"
             subtitle:^NSString *(id view) {
                 return [FLEXRuntimeUtility safeDescriptionForObject:controller];
@@ -84,7 +85,43 @@
                 return !CGRectIsEmpty(view.bounds) ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
             }
         ]
-    ]];
+    ].mutableCopy;
+    
+    // Add an "Animations Speed" Shortcut for UIWindows. Although the feature could
+    // be available on UIViews, we don't want to spam all UIViews with this Shortcut.
+    //
+    // Since as of now, FLEX doesn't support merging Shortcuts from different classes,
+    // we keep this in FLEXViewShortcuts. If it gets implemented in the future, we'll
+    // move this Shortcut to its own FLEXWindowShortcuts class.
+    if ([view isKindOfClass:[UIWindow class]]) {
+        [rows addObject:
+            [FLEXActionShortcut title:@"Animations Speed" subtitle:^NSString *(UIWindow *window) {
+                return [NSString stringWithFormat:@"Current speed: %.2f", window.layer.speed];
+            } selectionHandler:^(UIViewController *host, UIWindow *window) {
+                [FLEXAlert makeAlert:^(FLEXAlert *make) {
+                    make.title(@"Change Animations Speed");
+                    make.message([NSString stringWithFormat:@"Current speed: %.2f", window.layer.speed]);
+                    make.configuredTextField(^(UITextField * _Nonnull textField) {
+                        textField.placeholder = @"Speed value";
+                        textField.keyboardType = UIKeyboardTypeDecimalPad;
+                    });
+                    
+                    make.button(@"OK").handler(^(NSArray<NSString *> *strings) {
+                        CGFloat speedValue = strings.firstObject.floatValue;
+                        window.layer.speed = speedValue;
+
+                        // Refresh the host view controller to update the shortcut subtitle, reflecting current speed
+                        [(FLEXObjectExplorerViewController *)host reloadData];
+                    });
+                    make.button(@"Cancel").cancelStyle();
+                } showFrom:host];
+            } accessoryType:^UITableViewCellAccessoryType(id  _Nonnull object) {
+                return UITableViewCellAccessoryDisclosureIndicator;
+            }]
+        ];
+    }
+    
+    return [self forObject:view additionalRows:rows];
 }
 
 @end

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXViewShortcuts.m
@@ -11,7 +11,6 @@
 #import "FLEXRuntimeUtility.h"
 #import "FLEXObjectExplorerFactory.h"
 #import "FLEXImagePreviewViewController.h"
-#import "FLEXAlert.h"
 
 @interface FLEXViewShortcuts ()
 @property (nonatomic, readonly) UIView *view;
@@ -62,7 +61,7 @@
     // and go forward again and it will show if the view controller is nil or changed.
     UIViewController *controller = [FLEXViewShortcuts nearestViewControllerForView:view];
 
-    NSMutableArray *rows = @[
+    return [self forObject:view additionalRows:@[
         [FLEXActionShortcut title:@"Nearest View Controller"
             subtitle:^NSString *(id view) {
                 return [FLEXRuntimeUtility safeDescriptionForObject:controller];
@@ -85,43 +84,7 @@
                 return !CGRectIsEmpty(view.bounds) ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
             }
         ]
-    ].mutableCopy;
-    
-    // Add an "Animations Speed" Shortcut for UIWindows. Although the feature could
-    // be available on UIViews, we don't want to spam all UIViews with this Shortcut.
-    //
-    // Since as of now, FLEX doesn't support merging Shortcuts from different classes,
-    // we keep this in FLEXViewShortcuts. If it gets implemented in the future, we'll
-    // move this Shortcut to its own FLEXWindowShortcuts class.
-    if ([view isKindOfClass:[UIWindow class]]) {
-        [rows addObject:
-            [FLEXActionShortcut title:@"Animations Speed" subtitle:^NSString *(UIWindow *window) {
-                return [NSString stringWithFormat:@"Current speed: %.2f", window.layer.speed];
-            } selectionHandler:^(UIViewController *host, UIWindow *window) {
-                [FLEXAlert makeAlert:^(FLEXAlert *make) {
-                    make.title(@"Change Animations Speed");
-                    make.message([NSString stringWithFormat:@"Current speed: %.2f", window.layer.speed]);
-                    make.configuredTextField(^(UITextField * _Nonnull textField) {
-                        textField.placeholder = @"Speed value";
-                        textField.keyboardType = UIKeyboardTypeDecimalPad;
-                    });
-                    
-                    make.button(@"OK").handler(^(NSArray<NSString *> *strings) {
-                        CGFloat speedValue = strings.firstObject.floatValue;
-                        window.layer.speed = speedValue;
-
-                        // Refresh the host view controller to update the shortcut subtitle, reflecting current speed
-                        [(FLEXObjectExplorerViewController *)host reloadData];
-                    });
-                    make.button(@"Cancel").cancelStyle();
-                } showFrom:host];
-            } accessoryType:^UITableViewCellAccessoryType(id  _Nonnull object) {
-                return UITableViewCellAccessoryDisclosureIndicator;
-            }]
-        ];
-    }
-    
-    return [self forObject:view additionalRows:rows];
+    ]];
 }
 
 @end

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.h
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.h
@@ -1,0 +1,13 @@
+//
+//  FLEXWindowShortcuts.h
+//  FLEX
+//
+//  Created by AnthoPak on 26/09/2022.
+//
+
+#import "FLEXShortcutsSection.h"
+
+/// Adds "Animations Speed" shortcut for all windows
+@interface FLEXWindowShortcuts : FLEXShortcutsSection
+
+@end

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.m
@@ -1,0 +1,45 @@
+//
+//  FLEXWindowShortcuts.m
+//  FLEX
+//
+//  Created by AnthoPak on 26/09/2022.
+//
+
+#import "FLEXWindowShortcuts.h"
+#import "FLEXShortcut.h"
+#import "FLEXAlert.h"
+#import "FLEXObjectExplorerViewController.h"
+
+@implementation FLEXWindowShortcuts
+
+#pragma mark - Overrides
+
++ (instancetype)forObject:(UIView *)view {
+    return [self forObject:view additionalRows:@[
+        [FLEXActionShortcut title:@"Animations Speed" subtitle:^NSString *(UIWindow *window) {
+            return [NSString stringWithFormat:@"Current speed: %.2f", window.layer.speed];
+        } selectionHandler:^(UIViewController *host, UIWindow *window) {
+            [FLEXAlert makeAlert:^(FLEXAlert *make) {
+                make.title(@"Change Animations Speed");
+                make.message([NSString stringWithFormat:@"Current speed: %.2f", window.layer.speed]);
+                make.configuredTextField(^(UITextField * _Nonnull textField) {
+                    textField.placeholder = @"Speed value";
+                    textField.keyboardType = UIKeyboardTypeDecimalPad;
+                });
+                
+                make.button(@"OK").handler(^(NSArray<NSString *> *strings) {
+                    CGFloat speedValue = strings.firstObject.floatValue;
+                    window.layer.speed = speedValue;
+
+                    // Refresh the host view controller to update the shortcut subtitle, reflecting current speed
+                    [(FLEXObjectExplorerViewController *)host reloadData];
+                });
+                make.button(@"Cancel").cancelStyle();
+            } showFrom:host];
+        } accessoryType:^UITableViewCellAccessoryType(id  _Nonnull object) {
+            return UITableViewCellAccessoryDisclosureIndicator;
+        }]
+    ]];
+}
+
+@end


### PR DESCRIPTION
This PR adds a new Shortcut to UIWindow to change its animations speed. It basically replicates the "Slow Animations" feature, only available on the Simulator. The user can set the speed of his choice.

As explained in the comments, as of now I've added it to UIView Shortcuts class instead of creating a new one for UIWindow. This is done like this to prevent UIWindow Shortcuts to override UIView ones (since as of now, an object can only get the Shortcuts from one class). Having a separate UIWindow class would have imply duplicating current UIView Shortcuts, which is not desirable. Tell me if you'd prefer any other way of handling this situation.