### PR TITLE
Fix error-prone FLEX exclusion from release instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ pod 'FLEX', :configurations => ['Debug']
 
 ### Swift Package Manager
 
-In Xcode, navigate to `Build Settings > Build Options > Excluded Source File Names`. For your `Release` configuration, set it to `FLEX.o` like this to exclude all files with the `FLEX` prefix:
+In Xcode, navigate to `Build Settings > Build Options > Excluded Source File Names`. For your `Release` configuration, set it to `FLEX*` like this to exclude all files with the `FLEX` prefix:
 
 <img width=75% height=75% src=https://user-images.githubusercontent.com/1234765/98673373-8545c080-2357-11eb-9587-0743998e23ba.png>
 


### PR DESCRIPTION
Fixes https://github.com/FLEXTool/FLEX/commit/4f1ff7784d2fd7cbafce0d7cfb3af373a1afebe5#r84796860.

I chose to use `FLEX*` instead of `FLEX.*`, because it's even less error-prone, and it's consistent with https://github.com/FLEXTool/FLEX/blob/master/README.md#flex-files-added-manually-to-a-project.