### PR TITLE
Fix animation speed modification in other locales

### DIFF
--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.m
@@ -29,7 +29,7 @@
                 
                 make.button(@"OK").handler(^(NSArray<NSString *> *strings) {
                     NSNumberFormatter *formatter = [NSNumberFormatter new];
-                    [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
+                    formatter.numberStyle = NSNumberFormatterDecimalStyle;
                     CGFloat speedValue = [formatter numberFromString:strings.firstObject].floatValue;
                     window.layer.speed = speedValue;
 

--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXWindowShortcuts.m
@@ -28,7 +28,9 @@
                 });
                 
                 make.button(@"OK").handler(^(NSArray<NSString *> *strings) {
-                    CGFloat speedValue = strings.firstObject.floatValue;
+                    NSNumberFormatter *formatter = [NSNumberFormatter new];
+                    [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
+                    CGFloat speedValue = [formatter numberFromString:strings.firstObject].floatValue;
                     window.layer.speed = speedValue;
 
                     // Refresh the host view controller to update the shortcut subtitle, reflecting current speed


### PR DESCRIPTION
In some locales where the decimal separator isn't a dot, the animation speed editor doesn't work with decimal value.

The `UIKeyboardTypeDecimalPad` keyboard has a comma key in French, but it is then parsed expecting a dot for the decimal.

I changed it to use `NSNumberFormatter`, which is locale-aware, and correctly expects a comma as a decimal separator in such languages.
