### PR TITLE
Fix cURL null payload for compressed HTTP bodies

### DIFF
--- a/Classes/Network/FLEXHTTPTransactionDetailController.m
+++ b/Classes/Network/FLEXHTTPTransactionDetailController.m
@@ -529,11 +529,8 @@ typedef UIViewController *(^FLEXNetworkDetailRowSelectionFuture)(void);
 
 + (NSData *)postBodyDataForTransaction:(FLEXHTTPTransaction *)transaction {
     NSData *bodyData = transaction.cachedRequestBody;
-    if (bodyData.length > 0) {
-        NSString *contentEncoding = [transaction.request valueForHTTPHeaderField:@"Content-Encoding"];
-        if ([contentEncoding rangeOfString:@"deflate" options:NSCaseInsensitiveSearch].length > 0 || [contentEncoding rangeOfString:@"gzip" options:NSCaseInsensitiveSearch].length > 0) {
-            bodyData = [FLEXUtility inflatedDataFromCompressedData:bodyData];
-        }
+    if (bodyData.length > 0 && [FLEXUtility hasCompressedContentEncoding:transaction.request]) {
+        bodyData = [FLEXUtility inflatedDataFromCompressedData:bodyData];
     }
     return bodyData;
 }

--- a/Classes/Network/FLEXNetworkCurlLogger.m
+++ b/Classes/Network/FLEXNetworkCurlLogger.m
@@ -6,6 +6,7 @@
 //
 
 #import "FLEXNetworkCurlLogger.h"
+#import "FLEXUtility.h"
 
 @implementation FLEXNetworkCurlLogger
 
@@ -28,7 +29,12 @@
     }
 
     if (request.HTTPBody) {
-        NSString *body = [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding];
+        NSData *bodyData = request.HTTPBody;
+        if ([FLEXUtility hasCompressedContentEncoding:request]) {
+            bodyData = [FLEXUtility inflatedDataFromCompressedData:bodyData];
+        }
+        NSString *body = [[NSString alloc] initWithData:bodyData encoding:NSUTF8StringEncoding];
+        
         if (body != nil) {
             [curlCommandString appendFormat:@"-d \'%@\'", body];
         } else {

--- a/Classes/Utility/FLEXUtility.h
+++ b/Classes/Utility/FLEXUtility.h
@@ -51,6 +51,7 @@
 + (NSString *)prettyJSONStringFromData:(NSData *)data;
 + (BOOL)isValidJSONData:(NSData *)data;
 + (NSData *)inflatedDataFromCompressedData:(NSData *)compressedData;
++ (BOOL)hasCompressedContentEncoding:(NSURLRequest *)request;
 
 // Swizzling utilities
 

--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -413,6 +413,11 @@ BOOL FLEXConstructorsShouldRun() {
     return inflatedData;
 }
 
++ (BOOL)hasCompressedContentEncoding:(NSURLRequest *)request {
+    NSString *contentEncoding = [request valueForHTTPHeaderField:@"Content-Encoding"];
+    return ([contentEncoding rangeOfString:@"deflate" options:NSCaseInsensitiveSearch].length > 0 || [contentEncoding rangeOfString:@"gzip" options:NSCaseInsensitiveSearch].length > 0);
+}
+
 + (NSArray<UIWindow *> *)allWindows {
     BOOL includeInternalWindows = YES;
     BOOL onlyVisibleWindows = NO;


### PR DESCRIPTION
Issue:
- When tapping the "Copy curl" button the cURL string has missing request body (it shows as null) when the content is compressed (gzip, deflate)

Fix:
- I realized that the library already has a way to decode compressed payloads since the request body shows fine in the UI. So I just moved the check for `Content-Encoding` to `FLEXUtility` to reuse in the `FLEXNetworkCurlLogger` and call the inflate method from `FLEXUtility` when necessary.