### PR TITLE
Fix EXC_BAD_ACCESS in FLEXNetworkObserver

### DIFF
--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -285,7 +285,9 @@ static void _logos_method$_ungrouped$FIRDocumentReference$setData$merge$completi
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidSetData:error transactionID:requestID];
-        orig(error);
+        if (error != nil) {
+            orig(error);
+        }
     };
     
     // Forward invocation
@@ -313,7 +315,9 @@ static void _logos_method$_ungrouped$FIRDocumentReference$setData$mergeFields$co
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidSetData:error transactionID:requestID];
-        orig(error);
+        if (error != nil) {
+            orig(error);
+        }
     };
     
     // Forward invocation
@@ -333,7 +337,9 @@ static void _logos_method$_ungrouped$FIRDocumentReference$updateData$completion$
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidUpdateData:error transactionID:requestID];
-        orig(error);
+        if (error != nil) {
+            orig(error);
+        }
     };
     
     // Forward invocation
@@ -353,7 +359,9 @@ static void _logos_method$_ungrouped$FIRDocumentReference$deleteDocumentWithComp
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidDeleteDocument:error transactionID:requestID];
-        orig(error);
+        if (error != nil) {
+            orig(error);
+        }
     };
     
     // Forward invocation
@@ -371,7 +379,9 @@ static FIRDocumentReference * _logos_method$_ungrouped$FIRCollectionReference$ad
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidAddDocument:error transactionID:requestID];
-        orig(error);
+        if (error != nil) {
+            orig(error);
+        }
     };
 
     // Forward invocation

--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -285,7 +285,7 @@ static void _logos_method$_ungrouped$FIRDocumentReference$setData$merge$completi
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidSetData:error transactionID:requestID];
-        if (error != nil) {
+        if (orig != nil) {
             orig(error);
         }
     };
@@ -315,7 +315,7 @@ static void _logos_method$_ungrouped$FIRDocumentReference$setData$mergeFields$co
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidSetData:error transactionID:requestID];
-        if (error != nil) {
+        if (orig != nil) {
             orig(error);
         }
     };
@@ -337,7 +337,7 @@ static void _logos_method$_ungrouped$FIRDocumentReference$updateData$completion$
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidUpdateData:error transactionID:requestID];
-        if (error != nil) {
+        if (orig != nil) {
             orig(error);
         }
     };
@@ -359,7 +359,7 @@ static void _logos_method$_ungrouped$FIRDocumentReference$deleteDocumentWithComp
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidDeleteDocument:error transactionID:requestID];
-        if (error != nil) {
+        if (orig != nil) {
             orig(error);
         }
     };
@@ -379,7 +379,7 @@ static FIRDocumentReference * _logos_method$_ungrouped$FIRCollectionReference$ad
     void (^orig)(NSError *) = completion;
     completion = ^(NSError *error) {
         [FLEXNetworkRecorder.defaultRecorder recordFIRDidAddDocument:error transactionID:requestID];
-        if (error != nil) {
+        if (orig != nil) {
             orig(error);
         }
     };


### PR DESCRIPTION
the crash happened after I used FLEX and Firestore in my app, the root cause for it is trying to set error in Orig block and the
error value is nil so we need to check on it first  
<img width="1193" alt="Screen Shot 2023-03-08 at 2 02 53 PM" src="https://user-images.githubusercontent.com/24413703/223709831-cfb87cdd-0190-4234-ab61-088f610ea79c.png">
