### PR TITLE
Add Surmagic surfile

### DIFF
--- a/SM/Surfile
+++ b/SM/Surfile
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>output_path</key>
+        <string>build</string>
+        <key>framework</key>
+        <string>FLEX</string>
+        <key>targets</key>
+        <array>
+            <dict>
+                <key>sdk</key>
+                <string>iOS</string>
+                <key>project</key>
+                <string>FLEX.xcodeproj</string>
+                <key>scheme</key>
+                <string>FLEX</string>
+            </dict>
+            <dict>
+                <key>sdk</key>
+                <string>iOSSimulator</string>
+                <key>project</key>
+                <string>FLEX.xcodeproj</string>
+                <key>scheme</key>
+                <string>FLEX</string>
+            </dict>
+            <!--
+               Remove this comment and add more targets for Simulators and the Devices.
+            -->
+        </array>
+        <key>finalActions</key>
+        <array>
+            <string>openDirectory</string>
+        </array>
+    </dict>
+</plist>


### PR DESCRIPTION
Using [Surmagic](https://github.com/gurhub/surmagic), we can simplify the process of building xcframework that helps to decrease compile time for this pod.
This PR adds default SM config file so just need to run
```zsh
surmagic xcf
```
to get your pre-built xcframework
<img width="741" alt="image" src="https://user-images.githubusercontent.com/7117277/233576439-e2307f46-b6db-4f81-8fa5-5791ba212cf6.png">

We can feel it is easier to add `binary-version` to Release assets rather than just compress the snapshots of source code at release time