### PR TITLE
Fix a view controllers leaking when dismissed via escape key.

### DIFF
--- a/Classes/Manager/FLEXManager+Extensibility.m
+++ b/Classes/Manager/FLEXManager+Extensibility.m
@@ -17,6 +17,7 @@
 #import "FLEXFileBrowserController.h"
 #import "FLEXArgumentInputStructView.h"
 #import "FLEXUtility.h"
+#import "FLEXTabList.h"
 
 @interface FLEXManager (ExtensibilityPrivate)
 @property (nonatomic, readonly) UIViewController *topViewController;
@@ -175,6 +176,9 @@
     } description:@"Toggle (this) help menu"];
 
     [self registerDefaultSimulatorShortcutWithKey:UIKeyInputEscape modifiers:0 action:^{
+        if ([self.topViewController isKindOfClass:[UINavigationController class]]) {
+          [FLEXTabList.sharedList closeTab:(UINavigationController *)self.topViewController];
+        }
         [[self.topViewController presentingViewController] dismissViewControllerAnimated:YES completion:nil];
     } description:@"End editing text\n\t\tDismiss top view controller"];
 


### PR DESCRIPTION
I found that some view controllers (for example: FLEXHierarchyViewController) are effectively leaked when they're dismissed via the escape key. It looks like they're added as tabs to `FLEXTabList`, but only manually removed from `FLEXTabList` via their own dismiss callbacks. Given that the escape key shortcut bypasses custom dismiss methods and just calls `-dismissVIewController:animated:`, `FLEXTabList` ends up holding a strong reference to a view controller that's never used again.