### PR TITLE
Ignore AVAssetDownloadURLSession to avoid crashing. (FLEXTool#276)

### DIFF
--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -23,6 +23,7 @@
 #import "FLEXMethod.h"
 #import "Firestore.h"
 
+#import <AVFoundation/AVFoundation.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import <dispatch/queue.h>
@@ -662,15 +663,20 @@ static FIRDocumentReference * _logos_method$_ungrouped$FIRCollectionReference$ad
     Method originalResume = class_getInstanceMethod(class, selector);
     IMP implementation = imp_implementationWithBlock(^(NSURLSessionTask *slf) {
         
-        // iOS's internal HTTP parser finalization code is mysteriously not thread safe,
-        // invoking it asynchronously has a chance to cause a `double free` crash.
-        // This line below will ask for HTTPBody synchronously, make the HTTPParser
-        // parse the request, and cache them in advance. After that the HTTPParser
-        // will be finalized. Make sure other threads inspecting the request
-        // won't trigger a race to finalize the parser.
-        [slf.currentRequest HTTPBody];
+        // AVAggregateAssetDownloadTask deeply does not like to be looked at. Accessing -currentRequest or
+        // -originalRequest will crash. Do not try to observe these. https://github.com/FLEXTool/FLEX/issues/276
+        if (![slf isKindOfClass:[AVAggregateAssetDownloadTask class]]) {
+            // iOS's internal HTTP parser finalization code is mysteriously not thread safe,
+            // invoking it asynchronously has a chance to cause a `double free` crash.
+            // This line below will ask for HTTPBody synchronously, make the HTTPParser
+            // parse the request, and cache them in advance. After that the HTTPParser
+            // will be finalized. Make sure other threads inspecting the request
+            // won't trigger a race to finalize the parser.
+            [slf.currentRequest HTTPBody];
 
-        [FLEXNetworkObserver.sharedObserver URLSessionTaskWillResume:slf];
+            [FLEXNetworkObserver.sharedObserver URLSessionTaskWillResume:slf];
+        }
+
         ((void(*)(id, SEL))objc_msgSend)(
             slf, swizzledSelector
         );
@@ -1975,6 +1981,12 @@ didFinishDownloadingToURL:(NSURL *)location data:(NSData *)data
 }
 
 - (void)URLSessionTaskWillResume:(NSURLSessionTask *)task {
+    // AVAggregateAssetDownloadTask deeply does not like to be looked at. Accessing -currentRequest or
+    // -originalRequest will crash. Do not try to observe these. https://github.com/FLEXTool/FLEX/issues/276
+    if ([task isKindOfClass:[AVAggregateAssetDownloadTask class]]) {
+        return;
+    }
+
     // Since resume can be called multiple times on the same task, only treat the first resume as
     // the equivalent to connection:willSendRequest:...
     [self performBlock:^{


### PR DESCRIPTION
AVAggregateAssetDownloadTask deeply does not like to be looked at. Accessing -currentRequest or -originalRequest will crash. Do not try to observe these.

Fixes #276 