### PR TITLE
Fix: when data is nil, `isValidJSONData` will crash

### DIFF
--- a/Classes/Network/FLEXHTTPTransactionDetailController.m
+++ b/Classes/Network/FLEXHTTPTransactionDetailController.m
@@ -492,6 +492,10 @@ typedef UIViewController *(^FLEXNetworkDetailRowSelectionFuture)(void);
         }
     }
 
+    if (!data) {
+        data = [NSData data];
+    }
+    
     // FIXME (RKO): Don't rely on UTF8 string encoding
     UIViewController *detailViewController = nil;
     if ([FLEXUtility isValidJSONData:data]) {


### PR DESCRIPTION
fix crash