### PR TITLE
Handle HTTP body which is not a UTF8 text

### DIFF
--- a/Classes/Network/FLEXNetworkCurlLogger.m
+++ b/Classes/Network/FLEXNetworkCurlLogger.m
@@ -29,7 +29,16 @@
 
     if (request.HTTPBody) {
         NSString *body = [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding];
-        [curlCommandString appendFormat:@"-d \'%@\'", body];
+        if (body != nil) {
+            [curlCommandString appendFormat:@"-d \'%@\'", body];
+        } else {
+            // Fallback to using base64 encoding
+            [curlCommandString appendString:@"--data-binary @-"];
+
+            NSString* base64 = [request.HTTPBody base64EncodedStringWithOptions:0];
+            NSString* prefix = [NSString stringWithFormat:@"echo -n '%@' | base64 -D | ", base64];
+            [curlCommandString insertString:prefix atIndex:0];
+        }
     }
 
     return curlCommandString;

--- a/Classes/Network/FLEXNetworkCurlLogger.m
+++ b/Classes/Network/FLEXNetworkCurlLogger.m
@@ -35,8 +35,8 @@
             // Fallback to using base64 encoding
             [curlCommandString appendString:@"--data-binary @-"];
 
-            NSString* base64 = [request.HTTPBody base64EncodedStringWithOptions:0];
-            NSString* prefix = [NSString stringWithFormat:@"echo -n '%@' | base64 -D | ", base64];
+            NSString *base64 = [request.HTTPBody base64EncodedStringWithOptions:0];
+            NSString *prefix = [NSString stringWithFormat:@"echo -n '%@' | base64 -D | ", base64];
             [curlCommandString insertString:prefix atIndex:0];
         }
     }


### PR DESCRIPTION
If body is not a UTF8 text - encode body as base64 and feed it into cuRL using pipeline of shell commands.