### PR TITLE
Use requiredProperties and optionalProperties in debug description

### DIFF
--- a/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.m
+++ b/Classes/Utility/Runtime/Objc/Reflection/FLEXProtocol.m
@@ -52,9 +52,15 @@
 }
 
 - (NSString *)debugDescription {
-    return [NSString stringWithFormat:@"<%@ name=%@, %lu properties, %lu required methods, %lu optional methods, %lu protocols>",
+    if (@available(iOS 10.0, *)) {
+        return [NSString stringWithFormat:@"<%@ name=%@, %lu required properties, %lu optional properties %lu required methods, %lu optional methods, %lu protocols>",
+            NSStringFromClass(self.class), self.name, (unsigned long)self.requiredProperties.count, (unsigned long)self.optionalProperties.count,
+            (unsigned long)self.requiredMethods.count, (unsigned long)self.optionalMethods.count, (unsigned long)self.protocols.count];
+    } else {
+        return [NSString stringWithFormat:@"<%@ name=%@, %lu properties, %lu required methods, %lu optional methods, %lu protocols>",
             NSStringFromClass(self.class), self.name, (unsigned long)self.properties.count,
             (unsigned long)self.requiredMethods.count, (unsigned long)self.optionalMethods.count, (unsigned long)self.protocols.count];
+    }
 }
 
 - (void)examine {


### PR DESCRIPTION
On iOS 10 and above, `requiredProperties` and `optionalProperties` are preferred over the deprecated `properties`.

Since FLEX only requires iOS 9 and above, a fallback is provided for older versions.