### PR TITLE
Fix Xcode 15 SPM warning related to iOS 12 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,9 @@ enum FLEXBuildOptions {
     static let silenceWarnings = false
 }
 
-#if swift(>=5.7)
+#if swift(>=5.9)
+let platforms: [PackageDescription.SupportedPlatform] = [.iOS(.v12)]
+#elseif swift(>=5.7)
 let platforms: [PackageDescription.SupportedPlatform] = [.iOS(.v11)]
 #else
 let platforms: [PackageDescription.SupportedPlatform] = [.iOS(.v10)]


### PR DESCRIPTION
This PR fixes a Xcode 15 SPM warning related to iOS 12 support, which is the minimum version supported.