### PR TITLE
Supports displaying and searching by accessibilityIdentifier in the Hierarchy view.

### DIFF
--- a/Classes/Utility/FLEXUtility.m
+++ b/Classes/Utility/FLEXUtility.m
@@ -100,8 +100,9 @@ BOOL FLEXConstructorsShouldRun() {
         description = [description stringByAppendingFormat:@" %@", [self stringForCGRect:view.frame]];
     }
     
-    if (view.accessibilityLabel.length > 0) {
-        description = [description stringByAppendingFormat:@" · %@", view.accessibilityLabel];
+    if (view.accessibilityLabel.length > 0 || view.accessibilityIdentifier.length > 0) {
+        description = [description stringByAppendingFormat:@" · %@",
+                       view.accessibilityLabel.length > 0 ? view.accessibilityLabel : view.accessibilityIdentifier];
     }
     
     return description;


### PR DESCRIPTION
`accessibilityLabel` is read by VoiceOver to the end-user, and `accessibilityIdentifier` is developer-facing only and is primarily used to identify an accessible element to UI automation and testing tools.

See <https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/1623132-accessibilityidentifier> and <https://stackoverflow.com/a/39231117/456536>.

So `accessibilityIdentifier` would be better for developers.
