### PR TITLE
Clean up deprecated APIs

### DIFF
--- a/Classes/Core/Controllers/FLEXTableViewController.m
+++ b/Classes/Core/Controllers/FLEXTableViewController.m
@@ -96,7 +96,11 @@ CGFloat const kFLEXDebounceForExpensiveIO = 0.5;
         self.searchController.searchBar.placeholder = @"Filter";
         self.searchController.searchResultsUpdater = (id)self;
         self.searchController.delegate = (id)self;
-        self.searchController.dimsBackgroundDuringPresentation = NO;
+        if (@available(iOS 9.1, *)) {
+            self.searchController.obscuresBackgroundDuringPresentation = NO;
+        } else {
+            self.searchController.dimsBackgroundDuringPresentation = NO;
+        }
         self.searchController.hidesNavigationBarDuringPresentation = NO;
         /// Not necessary in iOS 13; remove this when iOS 13 is the minimum deployment target
         self.searchController.searchBar.delegate = self;

--- a/Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontsPickerView.m
+++ b/Classes/Editing/ArgumentInputViews/FLEXArgumentInputFontsPickerView.m
@@ -46,7 +46,13 @@
     UIPickerView *fontsPicker = [UIPickerView new];
     fontsPicker.dataSource = self;
     fontsPicker.delegate = self;
+    
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // Deprecated in iOS 13; from then on, selection is always shown
     fontsPicker.showsSelectionIndicator = YES;
+    #pragma clang diagnostic pop
+
     return fontsPicker;
 }
 

--- a/Classes/Utility/Keyboard/FLEXKeyboardHelpViewController.m
+++ b/Classes/Utility/Keyboard/FLEXKeyboardHelpViewController.m
@@ -29,7 +29,7 @@
     self.textView.backgroundColor = UIColor.blackColor;
     self.textView.textColor = UIColor.whiteColor;
     self.textView.font = [UIFont boldSystemFontOfSize:14.0];
-    self.navigationController.navigationBar.barStyle = UIBarStyleBlackOpaque;
+    self.navigationController.navigationBar.barStyle = UIBarStyleBlack;
     
     self.title = @"Simulator Shortcuts";
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(donePressed:)];


### PR DESCRIPTION
iOS 9 is nine years old, and by dropping support we can clean up several APIs which were deprecated in iOS 10.

I've also cleaned up a couple other deprecated APIs:
- dimsBackgroundDuringPresentation is deprecated in iOS 12 in favor of obscuresBackgroundDuringPresentation which is available starting in iOS 9.1
- UIBarStyleBlackOpaque is deprecated in iOS 13 in favor of UIBarStyleBlack which is available from iOS 3
- showsSelectionIndicator is deprecated in iOS 13. According to the deprecation warning, "This property has no effect on iOS 7 and later" so we can safely remove it.

As a follow up question: is there interest in raising the min iOS version even further? There are lots of `@available` checks for iOS 11 and 13 as well.