### PR TITLE
Fix crash when opening view debug hierarchy

### DIFF
--- a/Classes/ViewHierarchy/SnapshotExplorer/FHSView.m
+++ b/Classes/ViewHierarchy/SnapshotExplorer/FHSView.m
@@ -88,6 +88,10 @@
 @implementation FHSView (Snapshotting)
 
 + (UIImage *)drawView:(UIView *)view {
+    if (CGRectIsEmpty(view.bounds)) {
+        return [UIImage new];
+    }
+
     CGSize size = view.bounds.size;
     CGRect bounds = view.bounds;
     CGFloat minUnit = 1.f / UIScreen.mainScreen.scale;


### PR DESCRIPTION
```
*** Assertion failure in void _UIGraphicsBeginImageContextWithOptions(CGSize, BOOL, CGFloat, BOOL)(),
    UIGraphics.m:410
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'UIGraphicsBeginImageContext() failed to allocate CGBitampContext:
    size={0, 0}, scale=3.000000, bitmapInfo=0x2002.
    Use UIGraphicsImageRenderer to avoid this assert.'
libc++abi: terminating due to uncaught exception of type NSException
```
