### PR TITLE
removed Non-public API usage _setWidth:

### DIFF
--- a/Classes/Core/Controllers/FLEXTableViewController.m
+++ b/Classes/Core/Controllers/FLEXTableViewController.m
@@ -337,7 +337,7 @@ CGFloat const kFLEXDebounceForExpensiveIO = 0.5;
     ];
     
     for (UIBarButtonItem *item in self.toolbarItems) {
-        [item _setWidth:60];
+        item.width = 60;
         // This does not work for anything but fixed spaces for some reason
         // item.width = 60;
     }

--- a/Classes/Utility/Categories/UIBarButtonItem+FLEX.h
+++ b/Classes/Utility/Categories/UIBarButtonItem+FLEX.h
@@ -35,6 +35,4 @@
 /// @return the receiver
 - (UIBarButtonItem *)flex_withTintColor:(UIColor *)tint;
 
-- (void)_setWidth:(CGFloat)width;
-
 @end


### PR DESCRIPTION
Apple TestFlight automated check is now rejecting binary with FLEX for usage of _setWidth, this PR removes usage of Non-public API `_setWidth:`


![Screenshot 2024-12-11 at 12 50 00](https://github.com/user-attachments/assets/5e6557cc-d02c-482f-9265-57af90a3b795)
