### PR TITLE
Remove [UIApplication openURL:]

### DIFF
--- a/Classes/ObjectExplorers/Sections/Shortcuts/FLEXUIAppShortcuts.m
+++ b/Classes/ObjectExplorers/Sections/Shortcuts/FLEXUIAppShortcuts.m
@@ -54,20 +54,16 @@
     NSURL *url = [NSURL URLWithString:urlString];
     
     if (url) {
-        if (@available(iOS 10, *)) {
-            [app openURL:url options:@{
-                UIApplicationOpenURLOptionUniversalLinksOnly: @(universalOnly)
-            } completionHandler:^(BOOL success) {
-                if (!success) {
-                    [FLEXAlert showAlert:@"No Universal Link Handler"
-                        message:@"No installed application is registered to handle this link."
-                        from:host
-                    ];
-                }
-            }];
-        } else {
-            [app openURL:url];
-        }
+        [app openURL:url options:@{
+            UIApplicationOpenURLOptionUniversalLinksOnly: @(universalOnly)
+        } completionHandler:^(BOOL success) {
+            if (!success) {
+                [FLEXAlert showAlert:@"No Universal Link Handler"
+                    message:@"No installed application is registered to handle this link."
+                    from:host
+                ];
+            }
+        }];
     } else {
         [FLEXAlert showAlert:@"Error" message:@"Invalid URL" from:host];
     }


### PR DESCRIPTION
[UIApplication openURL:] has been deprecated since iOS 10, and has been rendered useless if compiling with Xcode 16. Since the earliest supported OS by FLEX is 10.3, let's remove this method from FLEX so that it doesn't trip static analyzers looking for the dead method.