### PR TITLE
fix: snapshot explorer crashes springboard on some iOS 18 devices

### DIFF
--- a/Classes/ViewHierarchy/SnapshotExplorer/FHSView.m
+++ b/Classes/ViewHierarchy/SnapshotExplorer/FHSView.m
@@ -123,7 +123,7 @@
     }
 
     if (!rootView.isHidden) {
-        rootView.hidden = YES;
+        [self _setHidden:YES forView:rootView];
         [hiddenViews addObject:rootView];
     }
 
@@ -140,7 +140,7 @@
     }
 
     for (UIView *v in viewsToUnhide) {
-        v.hidden = NO;
+        [self _setHidden:NO forView:v];
     }
 }
 
@@ -188,7 +188,7 @@
     NSMutableIndexSet *toUnhide = [NSMutableIndexSet new];
     [view.subviews flex_forEach:^(UIView *v, NSUInteger idx) {
         if (!v.isHidden) {
-            v.hidden = YES;
+            [self _setHidden:YES forView:v];
             [toUnhide addIndex:idx];
         }
     }];
@@ -196,10 +196,22 @@
     // Snapshot the view, then unhide the previously-unhidden views
     UIImage *snapshot = [self drawView:view];
     for (UIView *v in [view.subviews objectsAtIndexes:toUnhide]) {
-        v.hidden = NO;
+        [self _setHidden:NO forView:v];
     }
 
     return snapshot;
+}
+
++ (void)_setHidden:(BOOL)hidden forView:(UIView *)view {
+    // SpringBoard's SBHomeGrabberView responds to setHidden: but raises an exception
+    // if you try to use it.
+    // Catching the exception is less fragile than hardcoding classes to ignore
+    @try {
+        view.hidden = hidden;
+    } @catch (NSException *exception) {
+        NSString *hidingOrUnhiding = hidden ? @"hiding" : @"unhiding";
+        NSLog(@"Exception raised when %@ view %@: %@", hidingOrUnhiding, view, exception);
+    }
 }
 
 @end


### PR DESCRIPTION
Addressing issue #716: Attempting to enter the View Hierarchy Snapshot Explorer leads to a SpringBoard crash on iOS 18.2 (simulator) when using an iPhone 16 device.

This change introduces a helper method for hiding/unhiding views in `FHSView.m`, `_setHidden:forView:`, which handles potential exceptions raised when interacting with some classes.

For more details about the crash: https://github.com/FLEXTool/FLEX/issues/716